### PR TITLE
Update django dep to 1.11.28

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ cycler==0.10.0
 decorator==4.4.1
 deepdiff==3.3.0
 defusedxml==0.6.0
-django==1.11.25
+django==1.11.28
 dulwich==0.19.15
 elementpath==1.1.8
 entrypoints==0.3


### PR DESCRIPTION
While `aiida-core==1.0.1` depends on `django==1.11.25`, the newest `develop` version of `aiida-core` already shows that it can support `django~=2.2` with no issue. So setting the dependency of `aiidalab` to `django==1.11.28` is not a big issue, but will indeed solve a vulnerability.

When we update to `aiida-core==1.1.0`, however, this will be updated in any case. So it is in some ways also a temporary dependency bump - again, to remove the vulnerability of earlier `django` version.