### PR TITLE
Revert "Update django dep to 1.11.28"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ cycler==0.10.0
 decorator==4.4.1
 deepdiff==3.3.0
 defusedxml==0.6.0
-django==1.11.28
+django==1.11.25
 dulwich==0.19.15
 elementpath==1.1.8
 entrypoints==0.3


### PR DESCRIPTION
Reverts aiidalab/aiidalab#35

I did not test `aiida-core==1.0.1` compatibility with `django==1.11.28`. If @CasperWA tested this, feel free to cancel the PR.