### PR TITLE
Add GitHub actions continuous-integration workflow for testing.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: continuous-integration
 
-on:
-  [push]
+on: [push, pull_request]
 
 jobs:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: continuous-integration
+
+on:
+  [push]
+
+jobs:
+
+  test-app:
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    strategy:
+      matrix:
+        tag: [ stable, latest ]
+        browser: [ chrome, firefox ]
+      fail-fast: false
+
+    steps:
+
+      - name: Checkout home app
+        uses: actions/checkout@v2
+        with:
+          repository: aiidalab/aiidalab-home
+
+      - name: Check out the aiidalab repository
+        uses: actions/checkout@v2
+        with:
+          path: aiidalab-package
+
+      - name: Copy aiidalab into app directory
+        run: cp -r "${GITHUB_WORKSPACE}/aiidalab-package/aiidalab" "${GITHUB_WORKSPACE}/aiidalab"
+
+      - name: Test app
+        uses: aiidalab/aiidalab-test-app-action@v2
+        with:
+          image: aiidalab/aiidalab-docker-stack:${{ matrix.tag }}
+          browser: ${{ matrix.browser }}
+          notebooks: appstore.ipynb,start.ipynb


### PR DESCRIPTION
I think the test structure highlights that maybe, decoupling the `aiidalab` package from the home app was the wrong move after all. Regardless, I suggest that we move forward in this way for now and reconsider this structure at a later stage.