### PR TITLE
Install app dependencies with dedicated environment

### DIFF
--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -29,7 +29,7 @@ from .config import AIIDALAB_DEFAULT_GIT_BRANCH
 from .widgets import StatusHTML, Spinner
 from .git_util import GitManagedAppRepo as Repo
 from .utils import throttled
-from .kernel import AppKernel
+from .kernel import AppKernel, AppKernelError
 
 HTML_MSG_PROGRESS = """{}"""
 
@@ -61,7 +61,11 @@ class VersionSelectorWidget(ipw.VBox):
             disabled=True,
             style=style,
         )
-        self.info = StatusHTML('')
+        self.info = StatusHTML(
+            value='',
+            layout={'max_width': '600px'},
+            style=style,
+        )
 
         super().__init__(
             children=[self.installed_version, self.version_to_install, self.info],
@@ -118,14 +122,20 @@ class AiidaLabAppWatch:
 
     def _setup_observer(self, observer):
         """Schdule the event handler for the given observer."""
+        # Setup the event handler.
+        event_handler = self.AppPathFileSystemEventHandler(self.app)
+
         # Create local reference to resolved kernel prefix directory for performance.
         kernel_prefix = self.app._kernel.prefix.resolve()
 
-        observer.schedule(event_handler, self.app.path, recursive=True)
+        # Monitor Jupyter kernel directory:
+        observer.schedule(event_handler, self.app._kernel.jupyter_kernel_path.parent)  # jupyter kernel directory
+
+        # Monitor app top-level directory and all subdirectories recursively.
+        # We only monitor the top-level directory of the virtual environment to for performance.
+        observer.schedule(event_handler, self.app.path, recursive=False)
         for child in Path(self.app.path).iterdir():
             if child.is_dir():
-                # Only monitor top-level directory of app-specific virtual environment to avoid
-                # reaching the inotify watch limit.
                 observer.schedule(event_handler, child, recursive=child.resolve() != kernel_prefix)
         return observer
 
@@ -136,8 +146,6 @@ class AiidaLabAppWatch:
         """
         assert os.path.isdir(self.app.path)
         assert self._observer is None or not self._observer.isAlive()
-
-        event_handler = self.AppPathFileSystemEventHandler(self.app)
 
         self._observer = self._setup_observer(Observer())
         try:
@@ -238,6 +246,7 @@ class AiidaLabApp(traitlets.HasTraits):
 
     busy = traitlets.Bool(readonly=True)
     detached = traitlets.Bool(readonly=True, allow_none=True)
+    kernel_message = traitlets.Unicode(readonly=True, allow_none=True)
 
     @dataclass
     class AppRegistryData:
@@ -376,6 +385,7 @@ class AiidaLabApp(traitlets.HasTraits):
 
     def __init__(self, name, app_data, aiidalab_apps_path, watch=True):
         super().__init__()
+        self._busy = 0
 
         if app_data is None:
             self._registry_data = None
@@ -421,11 +431,13 @@ class AiidaLabApp(traitlets.HasTraits):
     @contextmanager
     def _show_busy(self):
         """Apply this decorator to indicate that the app is busy during execution."""
-        self.set_trait('busy', True)
+        self._busy += 1
+        self.set_trait('busy', self._busy > 0)
         try:
             yield
         finally:
-            self.set_trait('busy', False)
+            self._busy -= 1
+            self.set_trait('busy', self._busy > 0)
 
     def in_category(self, category):
         # One should test what happens if the category won't be defined.
@@ -448,6 +460,10 @@ class AiidaLabApp(traitlets.HasTraits):
         """Return the kernel instance for this app."""
         return AppKernel(self.name)
 
+    def _has_dependencies(self):
+        """Return True if this app has dependencies."""
+        return any(os.path.isfile(os.path.join(self.path, fn)) for fn in ('setup.py', 'requirements.txt'))
+
     def _install_dependencies(self):
         """Install dependencies for this app into the app-specific kernel environment."""
 
@@ -467,6 +483,22 @@ class AiidaLabApp(traitlets.HasTraits):
 
         # Neither 'setup.py' or 'requirements.txt' file present, nothing to do.
         return None
+
+    def install_kernel(self):
+        """Install the app-specific kernel and app dependencies."""
+        with self._show_busy():
+            assert os.path.isdir(self.path)
+            if not self._has_dependencies():
+                raise RuntimeError("Unable to install app kernel, app has no dependencies.")
+
+            yield "Install app kernel..."
+            self._kernel.install()
+            yield "Install app dependencies..."
+            try:
+                self._install_dependencies()
+            except CalledProcessError as error:
+                self._kernel.uninstall()  # rollback
+                raise RuntimeError(f"Failed to install app dependencies: {error.stderr.decode()}.")
 
     def install_app(self, version=None):
         """Installing the app."""
@@ -491,11 +523,7 @@ class AiidaLabApp(traitlets.HasTraits):
             rev = self._release_line.resolve_revision(re.sub('git:', '', version))
             check_output(['git', 'checkout', '--force', rev], cwd=self.path, stderr=STDOUT)
 
-            # Install environnment dependencies
-            yield "Install app kernel..."
-            self._kernel.install()
-            yield "Install app dependencies..."
-            self._install_dependencies()
+            yield from self.install_kernel()
 
             self.refresh()
             return 'git:' + rev
@@ -563,9 +591,21 @@ class AiidaLabApp(traitlets.HasTraits):
                     self.check_for_updates()
                     modified = self._repo.dirty()
                     self.set_trait('detached', self.installed_version is AppVersion.UNKNOWN or modified)
+                    if self._has_dependencies():
+                        try:
+                            if self._kernel.installed():
+                                self.set_trait('kernel_message', '')
+                            else:
+                                self.set_trait('kernel_message', 'App-specific kernel is not installed.')
+                        except AppKernelError as kernel_error:
+                            self.set_trait('kernel_message', str(kernel_error))
+                    else:
+                        self.set_trait('kernel_message', '')
+
                 else:
                     self.set_trait('updates_available', None)
                     self.set_trait('detached', None)
+                    self.set_trait('kernel_message', None)
 
     def refresh_async(self):
         """Asynchronized (non-blocking) refresh of the app state."""
@@ -692,7 +732,7 @@ class AppManagerWidget(ipw.VBox):
         body.layout = {'width': '600px'}
 
         # Setup install_info
-        self.install_info = StatusHTML()
+        self.install_info = StatusHTML(layout={'max_width': '600px'})
 
         # Setup buttons
         self.install_button = ipw.Button(description='Install', disabled=True)
@@ -704,6 +744,12 @@ class AppManagerWidget(ipw.VBox):
         self.update_button = ipw.Button(description='Update', disabled=True)
         self.update_button.on_click(self._update_app)
 
+        self.install_kernel_button = ipw.Button(description='Install kernel', disabled=True)
+        self.install_kernel_button.layout.visilibity = 'hidden'
+        self.install_kernel_button.button_style = 'success'
+        self.install_kernel_button.tooltip = 'Install the app-specific Python and Jupyter kernel and app dependencies.'
+        self.install_kernel_button.on_click(self._install_kernel)
+
         self.detachment_indicator = ipw.HTML()
         self.detachment_ignore = ipw.Checkbox(description="Ignore")
         self.detachment_ignore.observe(self._refresh_widget_state)
@@ -713,7 +759,9 @@ class AppManagerWidget(ipw.VBox):
 
         children = [
             ipw.HBox([app.logo, body]),
-            ipw.HBox([self.uninstall_button, self.install_button, self.update_button, self.spinner]),
+            ipw.HBox([
+                self.uninstall_button, self.install_button, self.update_button, self.spinner, self.install_kernel_button
+            ]),
             ipw.HBox([self.install_info]),
             ipw.HBox([self.detachment_indicator, self.detachment_ignore]),
         ]
@@ -726,6 +774,10 @@ class AppManagerWidget(ipw.VBox):
         self.version_selector.layout.visibility = 'visible' if with_version_selector else 'hidden'
         self.version_selector.disabled = True
         self.version_selector.version_to_install.observe(self._refresh_widget_state, 'value')
+
+        ipw.dlink((self.app, 'kernel_message'), (self.version_selector.info, 'message'),
+                  transform=lambda msg: HTML_MSG_FAILURE.format("Kernel not properly installed.") if msg else "")
+
         children.insert(1, self.version_selector)
 
         super().__init__(children=children)
@@ -825,9 +877,12 @@ class AppManagerWidget(ipw.VBox):
                 self.detachment_indicator.value = ''
             self.detachment_ignore.layout.visibility = 'visible' if detached else 'hidden'
 
+            self.install_kernel_button.layout.visibility = 'visible' if self.app.kernel_message else 'hidden'
+            self.install_kernel_button.disabled = busy or not self.app.kernel_message
+
     def _show_msg_progress(self, msg):
         """Show a message indicating currently executed operation."""
-        self.install_info.show_temporary_message(HTML_MSG_PROGRESS.format(msg))
+        self.install_info.show_temporary_message(HTML_MSG_PROGRESS.format(msg), clear_after=300)
 
     def _show_msg_success(self, msg):
         """Show a message indicating successful execution of a requested operation."""
@@ -835,7 +890,7 @@ class AppManagerWidget(ipw.VBox):
 
     def _show_msg_failure(self, msg):
         """Show a message indicating failure to execute a requested operation."""
-        self.install_info.show_temporary_message(HTML_MSG_FAILURE.format(msg))
+        self.install_info.show_temporary_message(HTML_MSG_FAILURE.format(msg), clear_after=10)
 
     def _check_detached_state(self):
         """Check whether the app is in a detached state which would prevent any install or other operations."""
@@ -866,6 +921,16 @@ class AppManagerWidget(ipw.VBox):
             self._show_msg_failure(str(error))
         else:
             self._show_msg_success("Updated app.")
+
+    def _install_kernel(self, _):
+        """Attempt to install the app kernel."""
+        try:
+            for msg in self.app.install_kernel():
+                self._show_msg_progress(msg)
+        except RuntimeError as error:
+            self._show_msg_failure(str(error))
+        else:
+            self._show_msg_success("Installed kernel.")
 
     def _uninstall_app(self, _):
         """Attempt to uninstall the app."""

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -121,7 +121,7 @@ class AiidaLabAppWatch:
         return f"<{type(self).__name__}(app={self.app!r})>"
 
     def _setup_observer(self, observer):
-        """Schdule the event handler for the given observer."""
+        """Schedule the event handler for the given observer."""
         # Setup the event handler.
         event_handler = self.AppPathFileSystemEventHandler(self.app)
 
@@ -520,7 +520,7 @@ class AiidaLabApp(traitlets.HasTraits):
                 check_output(['git', 'clone', url, self.path], cwd=os.path.dirname(self.path), stderr=STDOUT)
 
             # Switch to desired version
-            yield "Switch to desired version..."
+            yield "Switch to the desired version..."
             rev = self._release_line.resolve_revision(re.sub('git:', '', version))
             check_output(['git', 'checkout', '--force', rev], cwd=self.path, stderr=STDOUT)
 

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -435,12 +435,23 @@ class AiidaLabApp(traitlets.HasTraits):
         return AppKernel(self.name)
 
     def _install_dependencies(self):
-        """Install all missing dependencies for this app."""
+        """Install dependencies for this app into the app-specific kernel environment."""
+
+        # Install as editable package if 'setup.py' is present.
+        if os.path.isfile(os.path.join(self.path, 'setup.py')):
+            return run([self._kernel.executable, '-m', 'pip', 'install', '-e', '.'],
+                       capture_output=True,
+                       check=True,
+                       cwd=self.path)
+
+        # Otherwise, install from 'requirements.txt' if present.
         if os.path.isfile(os.path.join(self.path, 'requirements.txt')):
             return run([self._kernel.executable, '-m', 'pip', 'install', '-r', 'requirements.txt'],
                        capture_output=True,
                        check=True,
                        cwd=self.path)
+
+        # Neither 'setup.py' or 'requirements.txt' file present, nothing to do.
         return None
 
     def install_app(self, version=None):

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -400,6 +400,8 @@ class AiidaLabApp(traitlets.HasTraits):
 
         self.name = name
         self.path = os.path.join(aiidalab_apps_path, self.name)
+        self._environment = AppEnvironment(self.name)
+
         self.refresh_async()
 
         if watch:
@@ -458,7 +460,7 @@ class AiidaLabApp(traitlets.HasTraits):
     @property
     def environment(self):
         """Return the environment instance for this app."""
-        return AppEnvironment(self.name)
+        return self._environment
 
     def _has_dependencies(self):
         """Return True if this app has dependencies."""

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -126,10 +126,10 @@ class AiidaLabAppWatch:
         event_handler = self.AppPathFileSystemEventHandler(self.app)
 
         # Create local reference to resolved kernel prefix directory for performance.
-        kernel_prefix = self.app._kernel.prefix.resolve()
+        kernel_prefix = self.app.kernel.prefix.resolve()
 
         # Monitor Jupyter kernel directory:
-        observer.schedule(event_handler, self.app._kernel.jupyter_kernel_path.parent)  # jupyter kernel directory
+        observer.schedule(event_handler, self.app.kernel.jupyter_kernel_path.parent)  # jupyter kernel directory
 
         # Monitor app top-level directory and all subdirectories recursively.
         # We only monitor the top-level directory of the virtual environment to for performance.
@@ -456,7 +456,7 @@ class AiidaLabApp(traitlets.HasTraits):
             return False
 
     @property
-    def _kernel(self):
+    def kernel(self):
         """Return the kernel instance for this app."""
         return AppKernel(self.name)
 
@@ -469,14 +469,14 @@ class AiidaLabApp(traitlets.HasTraits):
 
         # Install as editable package if 'setup.py' is present.
         if os.path.isfile(os.path.join(self.path, 'setup.py')):
-            return run([self._kernel.executable, '-m', 'pip', 'install', '-e', '.'],
+            return run([self.kernel.executable, '-m', 'pip', 'install', '-e', '.'],
                        capture_output=True,
                        check=True,
                        cwd=self.path)
 
         # Otherwise, install from 'requirements.txt' if present.
         if os.path.isfile(os.path.join(self.path, 'requirements.txt')):
-            return run([self._kernel.executable, '-m', 'pip', 'install', '-r', 'requirements.txt'],
+            return run([self.kernel.executable, '-m', 'pip', 'install', '-r', 'requirements.txt'],
                        capture_output=True,
                        check=True,
                        cwd=self.path)
@@ -492,12 +492,12 @@ class AiidaLabApp(traitlets.HasTraits):
                 raise RuntimeError("Unable to install app kernel, app has no dependencies.")
 
             yield "Install app kernel..."
-            self._kernel.install()
+            self.kernel.install()
             yield "Install app dependencies..."
             try:
                 self._install_dependencies()
             except CalledProcessError as error:
-                self._kernel.uninstall()  # rollback
+                self.kernel.uninstall()  # rollback
                 raise RuntimeError(f"Failed to install app dependencies: {error.stderr.decode()}.")
 
     def install_app(self, version=None):
@@ -542,7 +542,7 @@ class AiidaLabApp(traitlets.HasTraits):
         # Perform uninstall process.
         with self._show_busy():
             try:
-                self._kernel.uninstall()
+                self.kernel.uninstall()
             except Exception as error:
                 raise RuntimeError(f"Failed to uninstall kernel: {error!s}")
             try:
@@ -593,7 +593,7 @@ class AiidaLabApp(traitlets.HasTraits):
                     self.set_trait('detached', self.installed_version is AppVersion.UNKNOWN or modified)
                     if self._has_dependencies():
                         try:
-                            if self._kernel.installed():
+                            if self.kernel.installed():
                                 self.set_trait('kernel_message', '')
                             else:
                                 self.set_trait('kernel_message', 'App-specific kernel is not installed.')

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -745,11 +745,13 @@ class AppManagerWidget(ipw.VBox):
         self.update_button = ipw.Button(description='Update', disabled=True)
         self.update_button.on_click(self._update_app)
 
-        self.install_environment_button = ipw.Button(description='Install environment', disabled=True)
+        self.install_environment_button = ipw.Button(
+            description='Install environment',
+            disabled=True,
+            button_style='success',
+            tooltip='Install the app-specific Python environment, Jupyter kernel, and app dependencies.',
+        )
         self.install_environment_button.layout.visilibity = 'hidden'
-        self.install_environment_button.button_style = 'success'
-        self.install_environment_button.tooltip = \
-                'Install the app-specific Python environment, Jupyter kernel, and app dependencies.'
         self.install_environment_button.on_click(self._install_environment)
 
         self.detachment_indicator = ipw.HTML()

--- a/aiidalab/environment.py
+++ b/aiidalab/environment.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from subprocess import run
 from urllib.parse import quote_plus
 
+from jupyter_core.paths import jupyter_data_dir
+
 from .config import AIIDALAB_APPS
 
 
@@ -68,7 +70,7 @@ class AppEnvironment:
 
     @property
     def jupyter_kernel_path(self):
-        return Path.home().joinpath('.local', 'share', 'jupyter', 'kernels', self.kernel_name)
+        return Path(jupyter_data_dir()).joinpath('kernels', self.kernel_name)
 
     def install(self, system_site_packages=True, clear=True):
         """Create the Python virtual environment and install the Jupyter kernel."""

--- a/aiidalab/environment.py
+++ b/aiidalab/environment.py
@@ -99,7 +99,7 @@ class AppEnvironment:
         if self.prefix.is_dir():
 
             if not self.executable.is_file():
-                raise AppEnvironmentError("The environment executable ('{self.executable}') is missing.")
+                raise AppEnvironmentError(f"The environment executable ('{self.executable}') is missing.")
 
             if not self.jupyter_kernel_path.is_dir():
                 raise AppEnvironmentError(

--- a/aiidalab/kernel.py
+++ b/aiidalab/kernel.py
@@ -67,6 +67,7 @@ class AppKernel:
     def install(self, system_site_packages=True, clear=True):
         """Create the Python virtual environment and install the Jupyter kernel."""
         venv.create(self.prefix, system_site_packages=system_site_packages, clear=clear)
+        run([self.executable, '-c', 'import reentry; reentry.manager.scan()'], check=True)
         run([self.executable, '-m', 'ipykernel', 'install', '--user', f'--name={self.name}'], check=True)
 
     def uninstall(self):

--- a/aiidalab/kernel.py
+++ b/aiidalab/kernel.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from subprocess import run
 from urllib.parse import quote_plus
 
-from .config import AIIDALAB_HOME
+from .config import AIIDALAB_APPS
 
 
 def _valid_jupyter_kernel_name(name):
@@ -56,7 +56,7 @@ class AppKernel:
 
     @property
     def prefix(self):
-        return Path(AIIDALAB_HOME).joinpath('.environments', self._app_name)
+        return Path(AIIDALAB_APPS).joinpath(self._app_name, '.venv')
 
     @property
     def executable(self):

--- a/aiidalab/kernel.py
+++ b/aiidalab/kernel.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+"""Manage Python environments and Jupyter kernels for apps."""
+import re
+import venv
+import shutil
+from hashlib import sha1
+from pathlib import Path
+from subprocess import run
+from urllib.parse import quote_plus
+
+from .config import AIIDALAB_HOME
+
+
+def _valid_jupyter_kernel_name(name):
+    """Check whether the given name is a valid Jupyter kernel name."""
+    return re.fullmatch(r'[a-z0-9\-\_.]+', name)
+
+
+class AppKernel:
+    """Manage Python environment and Jupyter kernel for AiiDA lab app.
+
+    Arguments:
+
+        app_name (str):
+            Name of the AiiDA lab app.
+    """
+
+    def __init__(self, app_name):
+        self._app_name = app_name
+
+    @property
+    def name(self):
+        """Generate unique name for this kernel based on the app name.
+
+        The kernel name is guaranteed to be a valid Jupyter kernel name
+        and unique with respect to the app name so to avoid kernel name
+        collisions between different apps.
+        """
+        # The unique_name is a hash value based on the app_name which is
+        # guaranteed to be truly unique with respect to the app name.
+        unique_name = sha1(self._app_name.encode()).hexdigest()
+
+        # The human-readable name is a name based on the app name that
+        # constitutes a valid Jupyter kernel name:
+        human_readable_name = quote_plus(self._app_name.replace('@', '.')).replace('%', '-')
+        kernel_name = f'{human_readable_name:.32}-{unique_name:.8}'
+
+        # Return only the unique_name in case that we failed to
+        # construct a valid kernel name:
+        if not _valid_jupyter_kernel_name(kernel_name):
+            return unique_name
+
+        return kernel_name
+
+    @property
+    def prefix(self):
+        return Path(AIIDALAB_HOME).joinpath('.environments', self._app_name)
+
+    @property
+    def executable(self):
+        return self.prefix.joinpath('bin', 'python')
+
+    @property
+    def jupyter_kernel_path(self):
+        return Path.home().joinpath('.local', 'share', 'jupyter', 'kernels', self.name)
+
+    def install(self, system_site_packages=True, clear=True):
+        """Create the Python virtual environment and install the Jupyter kernel."""
+        venv.create(self.prefix, system_site_packages=system_site_packages, clear=clear)
+        run([self.executable, '-m', 'ipykernel', 'install', '--user', f'--name={self.name}'], check=True)
+
+    def uninstall(self):
+        """Remove both the Python virtual environment and the corresponding Jupyter kernel."""
+        try:
+            shutil.rmtree(self.jupyter_kernel_path)
+        except FileNotFoundError:
+            pass  # kernel was not installed
+        try:
+            shutil.rmtree(self.prefix)
+        except FileNotFoundError:
+            pass  # environment was not installed
+
+    def check(self):
+        assert self.prefix.is_dir()
+        assert self.executable.is_file()
+        assert self.jupyter_kernel_path.is_dir()

--- a/aiidalab/kernel.py
+++ b/aiidalab/kernel.py
@@ -81,7 +81,6 @@ class AppKernel:
         except FileNotFoundError:
             pass  # environment was not installed
 
-    def check(self):
-        assert self.prefix.is_dir()
-        assert self.executable.is_file()
-        assert self.jupyter_kernel_path.is_dir()
+    def installed(self):
+        """Check whether this kernel is installed."""
+        return self.prefix.is_dir() and self.executable.is_file() and self.jupyter_kernel_path.is_dir()

--- a/aiidalab/kernel.py
+++ b/aiidalab/kernel.py
@@ -38,7 +38,9 @@ class AppKernel:
         """
         # The unique_name is a hash value based on the app_name which is
         # guaranteed to be truly unique with respect to the app name.
-        unique_name = sha1(self._app_name.encode()).hexdigest()
+        # The current schema version (1) is explicitly encoded to simplify
+        # potential future migrations.
+        unique_name = sha1(f'1/{self._app_name}'.encode()).hexdigest()
 
         # The human-readable name is a name based on the app name that
         # constitutes a valid Jupyter kernel name:

--- a/aiidalab/utils.py
+++ b/aiidalab/utils.py
@@ -18,7 +18,7 @@ import ipywidgets as ipw
 from IPython.lib import backgroundjobs as bg
 
 from .config import AIIDALAB_APPS, AIIDALAB_REGISTRY
-from .kernel import AppKernel, AppKernelError
+from .environment import AppEnvironment, AppEnvironmentError
 
 
 def update_cache():
@@ -72,10 +72,10 @@ def url_for(endpoint):
     except ValueError:
         raise ValueError("Endpoint argument to url_for() must be relative to the AIIDALAB_APPS path.")
 
-    app_kernel = AppKernel(app_name)
+    app_environment = AppEnvironment(app_name)
 
-    if app_kernel.installed():
-        query_string.setdefault('kernel_name', app_kernel.name)
+    if app_environment.installed():
+        query_string.setdefault('kernel_name', app_environment.kernel_name)
     else:  # Use fallback kernel:
         query_string.setdefault('kernel_name', 'python3')
 
@@ -93,8 +93,8 @@ def load_start_py(name):
             return mod.get_start_widget(appbase=appbase, jupbase=jupbase, notebase=notebase)
         except TypeError:
             return mod.get_start_widget(appbase=appbase, jupbase=jupbase)
-    except AppKernelError as error:
-        return ipw.HTML(f"<p>App kernel error: {error!s}</p><p>Reinstalling the app might resolve the issue.</p>")
+    except AppEnvironmentError as error:
+        return ipw.HTML(f"<p>App environment error: {error!s}</p><p>Reinstalling the app might resolve the issue.</p>")
     except Exception:  # pylint: disable=broad-except
         return ipw.HTML("<pre>{}</pre>".format(sys.exc_info()))
 
@@ -115,8 +115,8 @@ def load_start_md(name):
         html = html.replace("<h3", "<h4")
         return ipw.HTML(html)
 
-    except AppKernelError as error:
-        return ipw.HTML(f"<p>App kernel error: {error!s}</p><p>Reinstalling the app might resolve the issue.</p>")
+    except AppEnvironmentError as error:
+        return ipw.HTML(f"<p>App environment error: {error!s}</p><p>Reinstalling the app might resolve the issue.</p>")
 
     except Exception as exc:  # pylint: disable=broad-except
         return ipw.HTML("Could not load start.md: {}".format(str(exc)))

--- a/aiidalab/utils.py
+++ b/aiidalab/utils.py
@@ -18,7 +18,7 @@ import ipywidgets as ipw
 from IPython.lib import backgroundjobs as bg
 
 from .config import AIIDALAB_APPS, AIIDALAB_REGISTRY
-from .kernel import AppKernel
+from .kernel import AppKernel, AppKernelError
 
 
 def update_cache():
@@ -93,6 +93,8 @@ def load_start_py(name):
             return mod.get_start_widget(appbase=appbase, jupbase=jupbase, notebase=notebase)
         except TypeError:
             return mod.get_start_widget(appbase=appbase, jupbase=jupbase)
+    except AppKernelError as error:
+        return ipw.HTML(f"<p>App kernel error: {error!s}</p><p>Reinstalling the app might resolve the issue.</p>")
     except Exception:  # pylint: disable=broad-except
         return ipw.HTML("<pre>{}</pre>".format(sys.exc_info()))
 
@@ -112,6 +114,9 @@ def load_start_md(name):
         # downsize headings
         html = html.replace("<h3", "<h4")
         return ipw.HTML(html)
+
+    except AppKernelError as error:
+        return ipw.HTML(f"<p>App kernel error: {error!s}</p><p>Reinstalling the app might resolve the issue.</p>")
 
     except Exception as exc:  # pylint: disable=broad-except
         return ipw.HTML("Could not load start.md: {}".format(str(exc)))

--- a/aiidalab/widgets.py
+++ b/aiidalab/widgets.py
@@ -7,7 +7,7 @@ import traitlets
 import ipywidgets as ipw
 
 
-class _StatusWidgetMixin:
+class _StatusWidgetMixin(traitlets.HasTraits):
     """Show temporary messages for example for status updates.
 
     This is a mixin class that is meant to be part of an inheritance
@@ -16,13 +16,15 @@ class _StatusWidgetMixin:
     for examples.
     """
 
+    message = traitlets.Unicode(default_value='', allow_none=True)
+
     def __init__(self, *args, **kwargs):
         self._clear_timer = None
         super().__init__(*args, **kwargs)
 
     def _clear_value(self):
         """Set widget .value to be an empty string."""
-        self.value = ''
+        self.value = '' if self.message is None else self.message
 
     def show_temporary_message(self, value, clear_after=3):
         """Show a temporary message and clear it after the given interval."""
@@ -40,9 +42,21 @@ class _StatusWidgetMixin:
 class StatusLabel(_StatusWidgetMixin, ipw.Label):
     """Show temporary messages for example for status updates."""
 
+    # This method should be part of _StatusWidgetMixin, but that does not work
+    # for an unknown reason.
+    @traitlets.observe('message')
+    def _observe_message(self, change):
+        self.show_temporary_message(change['new'])
+
 
 class StatusHTML(_StatusWidgetMixin, ipw.HTML):
     """Show temporary HTML messages for example for status updates."""
+
+    # This method should be part of _StatusWidgetMixin, but that does not work
+    # for an unknown reason.
+    @traitlets.observe('message')
+    def _observe_message(self, change):
+        self.show_temporary_message(change['new'])
 
 
 class UpdateAvailableInfoWidget(ipw.HTML):


### PR DESCRIPTION
fixes #41 
fixes #68 
fixes #69 

This change set extends the app installation process to install a dedicated app-specific kernel where all app-specific dependencies are installed. The kernel installation process involves the setup of a virtual environment and the subsequent installation of the Python executable as kernel into the Jupyter kernelspec configuration within user space. The virtual environment uses system packages, so dependencies that are already present in the system environment, are used directly and not installed again.

The kernel is uniquely identified by its name which is a function of the app name, which prevents accidental name collisions. To ensure that app-specific notebooks are opened with the correct kernel, one must use the `aiidalab.utils.url_for()` function when creating intra- and inter-app links. For example, to link to another notebook within the same app, simply use `url_for('other_notebook.ipynb')` or `url_for('other/notebook.ipynb')`. The `url_for()` function will automatically add the correct kernel specification for the given URL. This works for both intra- and inter-app links. If an app has no kernel installed, this function will fallback to the default kernel (`python3`). Links that do not use the `url_for()` function will use the kernel specified in the notebook metadata or the default kernel, this must therefore be avoided.

App dependencies are installed by installing the app as an editable package if a `setup.py` file is present or – if that's not the case – by installing dependencies from a `requirements.txt` file if present. If neither file is present, no kernel and no dependencies are installed.