### PR TITLE
Make return value of AiidaLabApp.__repr__() valid Python expression.

### DIFF
--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -271,8 +271,8 @@ class AiidaLabApp(traitlets.HasTraits):
 
     def __repr__(self):
         app_data_argument = None if self._registry_data is None else asdict(self._registry_data)
-        return (f"<AiidaLabApp(name={self.name!r}, app_data={app_data_argument!r}, "
-                f"aiidalab_apps_path={os.path.dirname(self.path)!r})>")
+        return (f"AiidaLabApp(name={self.name!r}, app_data={app_data_argument!r}, "
+                f"aiidalab_apps_path={os.path.dirname(self.path)!r})")
 
     @traitlets.default('detached')
     def _default_detached(self):


### PR DESCRIPTION
@CasperWA I previously accepted your suggestion to add `<..>` delimiters to the `__repr__` return value of the `AiidaLabApp` class (as part of #81) however, the convention is not use these delimiters when `__repr__` actually returns a valid Python expressions, see also here:

 * https://docs.python.org/3.7/library/functions.html#repr
 * https://stackoverflow.com/a/1984177

This PR reverts that change.