### PR TITLE
Determine remote branch from release line instead of checked out branch.

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -81,7 +81,8 @@ def _register_hello_world_app(url, head):
         "groups": ["utilities"],
         "metainfo": app_data,
         "gitinfo": {
-            "refs/heads/master": head.decode(),
+            f"refs/heads/{DEFAULT_BRANCH}": head.decode(),
+            f"refs/heads/{TESTING_BRANCH}": head.decode(),
         },
     }
     assert aiidalab.config.AIIDALAB_REGISTRY.startswith('file://')


### PR DESCRIPTION
Makes installation flow robust against detached HEAD states.