### PR TITLE
Rename AiiDA lab to AiiDAlab and modify README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-[![Build Status](https://travis-ci.org/aiidalab/aiidalab-metapkg.svg?branch=master)](https://travis-ci.org/aiidalab/aiidalab-metapkg)
+[![Build Status](https://travis-ci.org/aiidalab/aiidalab.svg?branch=master)](https://travis-ci.org/aiidalab/aiidalab)
 [![Documentation Status](https://readthedocs.org/projects/aiidalab/badge/)](https://aiidalab.readthedocs.io/)
-# aiidalab-metapkg
+# AiiDAlab package
 
-The `aiidalab` metapackage sets up the python environment found on the 
-[AiiDA lab](https://aiidalab.materialscloud.org).
+The `aiidalab` package sets up the python environment found on the
+[AiiDAlab](https://aiidalab.materialscloud.org).
 Amongst others, this includes
 
- * aiida-core
  * a wide range of aiida plugins
  * jupyter
+ * AiiDAlab base widgets
  * ...
 
 The relevant jupyter notebook extensions are enabled automatically.

--- a/aiidalab/__init__.py
+++ b/aiidalab/__init__.py
@@ -1,3 +1,3 @@
-"""AiiDA lab core tools."""
+"""AiiDAlab core tools."""
 
 __version__ = "20.09.0b1"

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Module to manage AiiDA lab apps."""
+"""Module to manage AiiDAlab apps."""
 
 import re
 import os
@@ -50,7 +50,7 @@ class AiidaLabAppWatch:
     """Watch to monitor the app installation status.
 
     Create a watch instance to monitor the installation status of an
-    AiiDA lab app. This is achieved by monitoring the app repository
+    AiiDAlab app. This is achieved by monitoring the app repository
     for existance and changes.
 
     Arguments:
@@ -166,7 +166,7 @@ class AiidaLabAppWatch:
 
 
 class AiidaLabApp(traitlets.HasTraits):
-    """Manage installation status of an AiiDA lab app.
+    """Manage installation status of an AiiDAlab app.
 
     Arguments:
 

--- a/aiidalab/config.py
+++ b/aiidalab/config.py
@@ -1,4 +1,4 @@
-"""Module to manange AiiDA lab configuration."""
+"""Module to manange AiiDAlab configuration."""
 from os import getenv
 
 AIIDALAB_HOME = getenv('AIIDALAB_HOME', '/project')

--- a/aiidalab/git_util.py
+++ b/aiidalab/git_util.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Utility module for git-managed AiiDA lab apps."""
+"""Utility module for git-managed AiiDAlab apps."""
 import re
 from enum import Enum
 

--- a/aiidalab/utils.py
+++ b/aiidalab/utils.py
@@ -1,4 +1,4 @@
-"""Helpful utilities for the AiiDA lab tools."""
+"""Helpful utilities for the AiiDAlab tools."""
 
 import json
 import time
@@ -34,7 +34,7 @@ except ImportError:
 
 
 def load_app_registry():
-    """Load apps' information from the AiiDA lab registry."""
+    """Load apps' information from the AiiDAlab registry."""
     parsed_url = urlparse(AIIDALAB_REGISTRY)
     if parsed_url.scheme == 'file':
         with open(parsed_url.path) as file:

--- a/setup.json
+++ b/setup.json
@@ -3,7 +3,7 @@
     "version": "20.09.0b1",
     "author": "The AiiDA team",
     "author_email": "aiidalab@materialscloud.org",
-    "description": "Meta package for the AiiDA lab python environment.",
+    "description": "Meta package for the AiiDAlab python environment.",
     "url": "https://github.com/aiidalab/aiidalab-metapkg",
     "license": "MIT License",
     "classifiers": [

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # -*- coding: utf8 -*-
-"""Setting up base widgets for base package for AiiDA lab."""
+"""Setting up base widgets for base package for AiiDAlab."""
 import json
 
 from setuptools import setup, find_packages


### PR DESCRIPTION
Readme was referring to `aiidalab` as a meta-package. It is not
true anymore, as now the package contains the core features of the
AiiDAlab platform. Additionally, the link to the Travis tests has been
corrected.