### PR TITLE
Downgrade traitlets dependency to `~=4.0`

### DIFF
--- a/setup.json
+++ b/setup.json
@@ -21,7 +21,7 @@
         "pip~=20.0",
         "requests-cache~=0.5.2",
         "toml~=0.10",
-        "traitlets~=5.0",
+        "traitlets~=4.0",
         "urllib3~=1.24",
         "watchdog~=0.10.2"
     ],


### PR DESCRIPTION
This is needed to work on Quantum Mobile where the standard Python
version is 3.6. The >5.0 version of traitlets does not support it.