### PR TITLE
Added a more rigid test for the availability of the registry

### DIFF
--- a/aiidalab/utils.py
+++ b/aiidalab/utils.py
@@ -51,9 +51,13 @@ def load_app_registry():
             return json.loads(file.read())
     else:
         try:
-            return requests.get(AIIDALAB_REGISTRY).json()
-        except ValueError:
+            registry = requests.get(AIIDALAB_REGISTRY)
+            # Now check also the exit code, only accept a 200 (OK, request succeeded)
+            assert registry.status_code == 200
+            return registry.json()
+        except requests.exceptions.RequestException as e:
             print("Registry server is unavailable! Can't check for the updates")
+            print(e)
             return dict(apps=dict(), catgories=dict())
 
 


### PR DESCRIPTION
The `requests` can fail, according to: https://docs.python-requests.org/en/latest/user/quickstart/#errors-and-exceptions.

Here we introduce a more rigid test, catching `requests.exceptions.RequestException` which covers all relevant exceptions. In addition, we also check that the exit code of `request` is 200 according to: https://docs.python-requests.org/en/master/user/quickstart/#json-response-content.