### PR TITLE
🐛 FIX: Unloadable home page when offline

### DIFF
--- a/aiidalab/utils.py
+++ b/aiidalab/utils.py
@@ -52,7 +52,7 @@ def load_app_registry():
     else:
         try:
             return requests.get(AIIDALAB_REGISTRY).json()
-        except ValueError:
+        except (ValueError, requests.ConnectionError):
             print("Registry server is unavailable! Can't check for the updates")
             return dict(apps=dict(), catgories=dict())
 


### PR DESCRIPTION
Because of this, if https://aiidalab.materialscloud.org/ is offline (as it is currently),
you can't even start aiidalab 😒.

I suggest  you also look through the rest of the code-base,
to check if there is anywhere else that assumes an internet connection.