### PR TITLE
Do not delete apps directly, but move them into a trash directory.

### DIFF
--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -21,6 +21,7 @@ from typing import List
 from urllib.parse import urldefrag
 from urllib.parse import urlsplit
 from urllib.parse import urlunsplit
+from uuid import uuid4
 
 import requests
 import traitlets
@@ -116,8 +117,10 @@ class _AiidaLabApp:
             return self._repo.dirty()
 
     def uninstall(self):
+        trash_path = Path.home().joinpath(".trash", f"self.name-{uuid4()!s}")
         if self.path.exists():
-            shutil.rmtree(self.path)
+            trash_path.parent.mkdir(parents=True, exist_ok=True)
+            self.path.rename(trash_path)
 
     def find_matching_releases(self, specifier):
         matching_releases = [


### PR DESCRIPTION
This is to work-around issues on some network file systems, that may
have lingering locks on files within the repository directory. The clean
up of the trash directory should be handled as a service.