### PR TITLE
update widgets docs

### DIFF
--- a/docs/source/app_development/index.rst
+++ b/docs/source/app_development/index.rst
@@ -4,8 +4,6 @@
 Develop AiiDAlab apps
 #####################
 
-Overview of the separate in-depth sections in this part of the documentation:
-
 .. toctree::
     :maxdepth: 1
 

--- a/docs/source/app_development/widgets.rst
+++ b/docs/source/app_development/widgets.rst
@@ -11,7 +11,7 @@ We have created a collection of reusable widgets that are already integrated wit
 AiiDAlab widgets
 ****************
 
-AiiDAlab apps typically involve some of following steps:
+AiiDAlab apps typically involve some of the following steps:
 
  * prepare the input for a calculation (e.g. an atomic structure)
  * select computational resources and submit a calculation to AiiDA
@@ -49,7 +49,7 @@ Widgets and traitlets
 Widgets are eventful Python objects that display GUI components, such as a sliders, buttons, progress bars, drowdowns, etc.
 `ipywidgets`_ is a Python package that provides interactive widgets for the use in Jupyter notebooks.
 
-An Ipywidget has a parameter, whose value can be ovserved and accessed from Python.
+Widgets can have one or more attributes, whose value can be _ovserved_ and accessed from Python such that we can react to changes to their values.
 This is implemented using `traitlets <https://traitlets.readthedocs.io/>`_.
 
 For example, try the following code in a Jupyter notebook:
@@ -79,13 +79,13 @@ For example, try the following code in a Jupyter notebook:
 Creating your own widgets
 =========================
 
-Each ipywidget consists of a Python component that defines how to interact with the widget from Python,
+Each widget consists of a Python component that defines how to interact with the widget from Python,
 and a Javascript (or TypeScript) component that is responsible for the graphical representation of the widget and communicates updates back to the Jupyter kernel.
 
-If your goal is to combine existing widgets into new, reusable components, this can be done in Python without touching the Javascript component.
-See e.g. the `implementation of the AiiDAlab widgets <https://github.com/aiidalab/aiidalab-widgets-base>`_, most of which are of this type.
+If the goal is to combine existing widgets into new, reusable components, this can be done in Python without touching the Javascript component.
+See for example the `implementation of the AiiDAlab widgets <https://github.com/aiidalab/aiidalab-widgets-base>`_, most of which are of this type.
 
-If you would like to modify the appearance of an existing widget or create an entirely new visualization, you will need to write Javascript/TypeScript.
+To modify the appearance of an existing widget or to create an entirely new visualization, one needs to write Javascript/TypeScript.
 See the detailed `tutorial <https://ipywidgets.readthedocs.io/en/stable/examples/Widget%20Custom.html>`_ on how to develop a custom widget or have a look at some of the examples from :ref:`develop-apps:widgets:more-widgets`.
 
 .. _ipywidgets: https://ipywidgets.readthedocs.io

--- a/docs/source/app_development/widgets.rst
+++ b/docs/source/app_development/widgets.rst
@@ -1,106 +1,91 @@
 .. _develop-apps:widgets:
 
-######################
-Using AiiDAlab widgets
-######################
+####################
+Use AiiDAlab widgets
+####################
 
-AiiDAlab largely dependents on Jupyter widgets for the graphical user interface (GUI).
-More specifically, the `Ipywidgets <https://ipywidgets.readthedocs.io/>`_ package is the primary tool for creating AiiDAlab apps.
-We have also created the `aiidalab-widgets-base <https://github.com/aiidalab/aiidalab-widgets-base>`_ that is based on `Ipywidgets` and provides tools to interact with AiiDA.
-
-**********
-Ipywidgets
-**********
-
-`Ipywidgets <https://ipywidgets.readthedocs.io/>`_ is a python package that provides interactive widgets to be used in Jupyter notebooks.
-Widgets are eventful python objects, which shows GUI components such as a slider, button, etc.
-
-Ipywidgets package provides base widgets like sliders, progress bar, buttons, checkbox, dropdown, radio buttons, text, text area, label, etc.
-The widgets have properties and value, which can be connected to the python codes and updated dynamically.
-For a simple example, one can use a slider to control the value of a variable.
-
-.. code-block:: python
-
-    from ipywidgets import FloatSlider
-
-    w = FloatSlider(value=0.0, min=0.0, max=10.0, description="b:");
-    a = 0.0;
-
-    def slider_change(change):
-        global a
-
-        print(change["old"])
-        print(change["new"])
-
-        a = a + w.value
-
-    a.obersve(slider_change, names="value")
-
-In this example, the ``slider_change`` function will be called each time the slider' value being updated.
-
-Traitlets
-=================
-
-In ipywidgets, all the widgets are using the `traitlets <https://traitlets.readthedocs.io/>`_ types for the parameters.
-As shown in the example above, the value of the ``FloatSlider`` is a ``Float`` trait type.
-One can not only show the current value ``value["new"]`` but also the old value ``value["old"]``.
-Traits can emit change events when the attributes are updated.
-This is very useful for creating custom widgets.
-
-Custom widgets
-==============
-
-Ipywidgets package also supports developers in creating their own widgets.
-There is a detailed `tutorial <https://ipywidgets.readthedocs.io/en/stable/examples/Widget%20Custom.html>`_ to show how to develop a custom widget.
-In the ipywidgets framework is based on the Comm framework.
-In the Comm framework, the change events of the traits leads to send a json massage to the Jupyter kernel.
-Then, the frontend will update accordingly.
-
-Develop the custom widgets mainly involve two parts:
-
-* **Python**: in the Python part, one needs to define the APIs of the widgets.
-  For instance, the color of the widget's background.
-  The traits types should be initialized as:
-
-
-.. code-block:: python
-
-    from traitlets import Unicode
-
-    color = Unicode('').tag(sync=True)
-
-* **Javascript** (or TypeScript): the javascript part is for the frontend of the widgets.
-  The frontend uses the `backbone.js <https://backbonejs.org/>`_ framework.
-  The communications between the Python and Javascript parts are from the set and get functions of the traits.
-
-.. code-block:: javascript
-
-    let color = this.model.get('color');
-
-    this.model.set('color', 'red');
-
-The change of the traits can be monitored and triggle javascript function.
-
-.. code-block:: javascript
-
-    this.model.on('change:color', this._color_change);
-
-Here is a list for some useful custom widgets:
-
-* `widget-periodictable <https://github.com/osscar-org/widget-periodictable>`_ : A interactive periodic table.
-* `widget-bandsplot <https://github.com/osscar-org/widget-bandsplot>`_ : A widget to plot bandstructure and density of states.
-* `widget-jsmol <https://github.com/osscar-org/widget-jsmol>`_ : A widget to use the molecular visualizer Jmol inside the Jupyter.
+AiiDAlab largely relies on `Jupyter widgets <https://ipywidgets.readthedocs.io/en/latest/>`_, also known as ``ipywidgets``, for the graphical user interface (GUI).
+We have created a collection of reusable widgets that are already integrated with AiiDA and help you accomplish common tasks.
 
 *********************
 AiiDAlab base widgets
 *********************
 
-Molecular and material simulations always need database parser, molecular visulizer and editor, image render tools etc.
-Here, we privde the `aiidalab-widgets-base <https://github.com/aiidalab/aiidalab-widgets-base>`_ , which is a collection of these tools.
-Developers can easily reuse it to develop AiiDAlab apps.
-Read more information at `https://aiidalab-widgets-base.readthedocs.io <https://aiidalab-widgets-base.readthedocs.io/>`_ .
+AiiDAlab apps typically involve some of following steps:
+
+ * prepare the input for a calculation (e.g. an atomic structure)
+ * select computational resources and submit a calculation to AiiDA
+ * monitor a running calculation
+ * find and analyze the results of a calculation
+
+The AiiDAlab base widgets help with these common tasks and are preinstalled in the AiiDAlab environment.
+Please see `https://aiidalab-widgets-base.readthedocs.io <https://aiidalab-widgets-base.readthedocs.io/>`_ for documentation on the individual widgets.
 
 .. image:: ./include/aiidalab-widgets-base.gif
     :width: 600px
     :align: center
     :alt: text
+
+
+.. _develop-apps:widgets:more-widgets:
+
+************
+More widgets
+************
+
+* `ipywidgets`_: basic GUI components, such as a text, sliders, buttons, progress bars, drowdowns, etc.
+* `widget-periodictable <https://github.com/osscar-org/widget-periodictable>`_ : interactive periodic table for element selection
+* `widget-bandsplot <https://github.com/osscar-org/widget-bandsplot>`_ : plot electronic bandstructure and density of states
+* `widget-jsmol <https://github.com/osscar-org/widget-jsmol>`_ : use the JSmol molecular visualizer inside a Jupyter notebook
+
+
+**************************
+Terminology and background
+**************************
+
+Widgets and traitlets
+======================
+
+Widgets are eventful Python objects that display GUI components, such as a sliders, buttons, progress bars, drowdowns, etc.
+`ipywidgets`_ is a Python package that provides interactive widgets for the use in Jupyter notebooks.
+
+An Ipywidget has a parameter, whose value can be ovserved and accessed from Python.
+This is implemented using `traitlets <https://traitlets.readthedocs.io/>`_.
+
+For example, try the following code in a Jupyter notebook:
+
+.. code-block:: python
+
+    from ipywidgets import FloatSlider
+
+    # slider widget that has a `value` traitlet attribute
+    slider = FloatSlider(value=273.0, min=100.0, max=500.0, description="Temperature [K]");
+
+    # Access the slider value as `slider.value`
+    # print(slider.value)
+
+    def slider_change(change):
+        """Handle slider changes.
+
+        This function is called when the slider value is changed by the user.
+        """
+        print(change["old"])
+        print(change["new"])
+        if change["new"] > 373.0:
+            print("Boiling now!")
+
+    slider.observe(slider_change, names="value")
+
+Creating your own widgets
+=========================
+
+Each ipywidget consists of a Python component that defines how to interact with the widget from Python,
+and a Javascript (or TypeScript) component that is responsible for the graphical representation of the widget and communicates updates back to the Jupyter kernel.
+
+If your goal is to combine existing widgets into new, reusable components, this can be done in Python without touching the Javascript component.
+See e.g. the `implementation of the AiiDAlab base widgets <https://github.com/aiidalab/aiidalab-widgets-base>`_, most of which are of this type.
+
+If you would like to modify the appearance of an existing widget or create an entirely new visualization, you will need to write Javascript/TypeScript.
+See the detailed `tutorial <https://ipywidgets.readthedocs.io/en/stable/examples/Widget%20Custom.html>`_ on how to develop a custom widget or have a look at some of the examples from :ref:`develop-apps:widgets:more-widgets`.
+
+.. _ipywidgets: https://ipywidgets.readthedocs.io

--- a/docs/source/app_development/widgets.rst
+++ b/docs/source/app_development/widgets.rst
@@ -7,9 +7,9 @@ Use AiiDAlab widgets
 AiiDAlab largely relies on `Jupyter widgets <https://ipywidgets.readthedocs.io/en/latest/>`_, also known as ``ipywidgets``, for the graphical user interface (GUI).
 We have created a collection of reusable widgets that are already integrated with AiiDA and help you accomplish common tasks.
 
-*********************
-AiiDAlab base widgets
-*********************
+****************
+AiiDAlab widgets
+****************
 
 AiiDAlab apps typically involve some of following steps:
 
@@ -18,7 +18,7 @@ AiiDAlab apps typically involve some of following steps:
  * monitor a running calculation
  * find and analyze the results of a calculation
 
-The AiiDAlab base widgets help with these common tasks and are preinstalled in the AiiDAlab environment.
+The AiiDAlab widgets help with these common tasks and are preinstalled in the AiiDAlab environment.
 Please see `https://aiidalab-widgets-base.readthedocs.io <https://aiidalab-widgets-base.readthedocs.io/>`_ for documentation on the individual widgets.
 
 .. image:: ./include/aiidalab-widgets-base.gif
@@ -83,7 +83,7 @@ Each ipywidget consists of a Python component that defines how to interact with 
 and a Javascript (or TypeScript) component that is responsible for the graphical representation of the widget and communicates updates back to the Jupyter kernel.
 
 If your goal is to combine existing widgets into new, reusable components, this can be done in Python without touching the Javascript component.
-See e.g. the `implementation of the AiiDAlab base widgets <https://github.com/aiidalab/aiidalab-widgets-base>`_, most of which are of this type.
+See e.g. the `implementation of the AiiDAlab widgets <https://github.com/aiidalab/aiidalab-widgets-base>`_, most of which are of this type.
 
 If you would like to modify the appearance of an existing widget or create an entirely new visualization, you will need to write Javascript/TypeScript.
 See the detailed `tutorial <https://ipywidgets.readthedocs.io/en/stable/examples/Widget%20Custom.html>`_ on how to develop a custom widget or have a look at some of the examples from :ref:`develop-apps:widgets:more-widgets`.

--- a/docs/source/app_development/widgets.rst
+++ b/docs/source/app_development/widgets.rst
@@ -49,7 +49,7 @@ Widgets and traitlets
 Widgets are Python objects that display GUI components, such as a sliders, buttons, progress bars, drowdowns, etc.
 `ipywidgets`_ is a Python package that provides interactive widgets for the use in Jupyter notebooks.
 
-Widgets can have one or more attributes, whose value can be _ovserved_ and accessed from Python such that we can react to changes to their values.
+Widgets can have one or more attributes, whose value can be _observed_ and accessed from Python such that we can react to changes to their values.
 This is implemented using `traitlets <https://traitlets.readthedocs.io/>`_.
 
 For example, try the following code in a Jupyter notebook:

--- a/docs/source/app_development/widgets.rst
+++ b/docs/source/app_development/widgets.rst
@@ -13,10 +13,10 @@ AiiDAlab widgets
 
 AiiDAlab apps typically involve some of the following steps:
 
- * prepare the input for a calculation (e.g. an atomic structure)
- * select computational resources and submit a calculation to AiiDA
- * monitor a running calculation
- * find and analyze the results of a calculation
+ * Prepare the input for a calculation (e.g. an atomic structure).
+ * Select computational resources and submit a calculation to AiiDA.
+ * Monitor a running calculation.
+ * Find and analyze the results of a calculation.
 
 The AiiDAlab widgets help with these common tasks and are preinstalled in the AiiDAlab environment.
 Please see `https://aiidalab-widgets-base.readthedocs.io <https://aiidalab-widgets-base.readthedocs.io/>`_ for documentation on the individual widgets.
@@ -46,7 +46,7 @@ Terminology and background
 Widgets and traitlets
 ======================
 
-Widgets are eventful Python objects that display GUI components, such as a sliders, buttons, progress bars, drowdowns, etc.
+Widgets are Python objects that display GUI components, such as a sliders, buttons, progress bars, drowdowns, etc.
 `ipywidgets`_ is a Python package that provides interactive widgets for the use in Jupyter notebooks.
 
 Widgets can have one or more attributes, whose value can be _ovserved_ and accessed from Python such that we can react to changes to their values.
@@ -69,8 +69,6 @@ For example, try the following code in a Jupyter notebook:
 
         This function is called when the slider value is changed by the user.
         """
-        print(change["old"])
-        print(change["new"])
         if change["new"] > 373.0:
             print("Boiling now!")
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,10 +4,7 @@ Welcome to AiiDAlab's documentation!
 
 AiiDAlab is a web platform that enables computational scientists to package scientific workflows and computational environments into "apps" and to share those apps with their collaborators and peers.
 
-AiiDAlab builds on
-
-   * `AiiDA <https://www.aiida.net/>`_ as the computational workflow engine
-   * the `Jupyter <https://jupyter.org/>`_ environment (notebooks, widgets, ...) for writing and sharing apps
+AiiDAlab builds on `AiiDA <https://www.aiida.net/>`_ as the computational workflow engine, and the `Jupyter <https://jupyter.org/>`_ environment (notebooks, widgets, ...) for writing and sharing apps.
 
 .. toctree::
    :maxdepth: 1
@@ -17,13 +14,6 @@ AiiDAlab builds on
    Develop AiiDAlab apps <app_development/index.rst>
    Develop AiiDAlab <development/index.rst>
    API documentation <apidoc/aiidalab>
-
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
 
 
 ***********
@@ -39,3 +29,10 @@ Acknowledgements
 ****************
 
 This work is supported by the `MARVEL National Centre for Competency in Research <http://nccr-marvel.ch>`__	funded by the `Swiss National Science Foundation <http://www.snf.ch/en>`__, as well as by the `MaX European Centre of Excellence <http://www.max-centre.eu/>`__ funded by the Horizon 2020 EINFRA-5 program, Grant No. 676598.
+
+******************
+Indices and tables
+******************
+
+* :ref:`genindex`
+* :ref:`modindex`


### PR DESCRIPTION
* reorder docs according to priority of information (start with aiidalab base widgets, then provide links to more examples, then add some background info for those who are interested)
* revise language
* remove js/python code illustrations for custom widgets - this bloats
  this page, would need to be maintained, and should be left to
  the ipywidgets docs