### PR TITLE
Update package management logic.

### DIFF
--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -34,6 +34,7 @@ from .config import AIIDALAB_APPS
 from .git_util import GitManagedAppRepo as Repo
 from .git_util import git_clone
 from .utils import (
+    _TTL_CACHE,
     find_installed_packages,
     load_app_registry_entry,
     run_pip_install,
@@ -518,6 +519,7 @@ class AiidaLabApp(traitlets.HasTraits):
         """Installing the app."""
         with self._show_busy():
             self._app.install(version=version, stdout=stdout)
+            _TTL_CACHE.clear()
             self.refresh()
             return self._installed_version()
 
@@ -527,6 +529,7 @@ class AiidaLabApp(traitlets.HasTraits):
             # Installing with version=None automatically selects latest
             # available version.
             version = self.install_app(version=None, stdout=stdout)
+            _TTL_CACHE.clear()
             self.refresh()
             return version
 

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -552,11 +552,11 @@ class AiidaLabApp(traitlets.HasTraits):
                 self._app.find_incompatibilities(version=app_version)
             )
             self.compatibility_info = {
-                    app_version: [
-                        f"({eco_system}) {requirement}"
-                        for eco_system, requirement in incompatibilities.items()
-                    ]
-                }
+                app_version: [
+                    f"({eco_system}) {requirement}"
+                    for eco_system, requirement in incompatibilities.items()
+                ]
+            }
 
             return not any(incompatibilities)
         except KeyError:

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -34,7 +34,7 @@ from .config import AIIDALAB_APPS
 from .git_util import GitManagedAppRepo as Repo
 from .git_util import git_clone
 from .utils import (
-    _TTL_CACHE,
+    FIND_INSTALLED_PACKAGES_CACHE,
     find_installed_packages,
     load_app_registry_entry,
     run_pip_install,
@@ -519,7 +519,7 @@ class AiidaLabApp(traitlets.HasTraits):
         """Installing the app."""
         with self._show_busy():
             self._app.install(version=version, stdout=stdout)
-            _TTL_CACHE.clear()
+            FIND_INSTALLED_PACKAGES_CACHE.clear()
             self.refresh()
             return self._installed_version()
 
@@ -529,7 +529,7 @@ class AiidaLabApp(traitlets.HasTraits):
             # Installing with version=None automatically selects latest
             # available version.
             version = self.install_app(version=None, stdout=stdout)
-            _TTL_CACHE.clear()
+            FIND_INSTALLED_PACKAGES_CACHE.clear()
             self.refresh()
             return version
 

--- a/aiidalab/utils.py
+++ b/aiidalab/utils.py
@@ -124,7 +124,7 @@ class Package:
         )
 
 
-@cached(cache=_TTL_CACHE)
+@cached(cache=FIND_INSTALLED_PACKAGES_CACHE)
 def find_installed_packages(python_bin=None):
     """Return all currently installed packages."""
     if python_bin is None:

--- a/aiidalab/utils.py
+++ b/aiidalab/utils.py
@@ -124,7 +124,7 @@ class Package:
         )
 
 
-@cached(cache=TTLCache(maxsize=32, ttl=60))
+@cached(cache=TTLCache(maxsize=32, ttl=5))
 def find_installed_packages(python_bin=None):
     """Return all currently installed packages."""
     if python_bin is None:

--- a/aiidalab/utils.py
+++ b/aiidalab/utils.py
@@ -19,7 +19,7 @@ from packaging.utils import canonicalize_name
 from .config import AIIDALAB_REGISTRY
 
 logger = logging.getLogger(__name__)
-_TTL_CACHE = TTLCache(maxsize=32, ttl=60)
+FIND_INSTALLED_PACKAGES_CACHE = TTLCache(maxsize=32, ttl=60)
 
 # Warning: try-except is a fix for Quantum Mobile release v19.03.0 where
 # requests_cache is not installed.

--- a/aiidalab/utils.py
+++ b/aiidalab/utils.py
@@ -19,7 +19,7 @@ from packaging.utils import canonicalize_name
 from .config import AIIDALAB_REGISTRY
 
 logger = logging.getLogger(__name__)
-
+_TTL_CACHE = TTLCache(maxsize=32, ttl=60)
 
 # Warning: try-except is a fix for Quantum Mobile release v19.03.0 where
 # requests_cache is not installed.
@@ -124,7 +124,7 @@ class Package:
         )
 
 
-@cached(cache=TTLCache(maxsize=32, ttl=5))
+@cached(cache=_TTL_CACHE)
 def find_installed_packages(python_bin=None):
     """Return all currently installed packages."""
     if python_bin is None:


### PR DESCRIPTION
1. Any (unstaged or staged) changes will set the app version to "unknown".
2. Remove the concept of incompatible versions, as we are now installing
the dependenices.
3. Show compatibility info only for the currently installed version.
4. Show all available prereleases or releases even if they are
incompatible with the current environment.
5. Reduce the caching time of the find_installed_packages function. This
is needed to update the compatibility info of a freshly installed package.