### PR TITLE
Parse metadata from app repository for non-registered apps.

### DIFF
--- a/aiidalab/__main__.py
+++ b/aiidalab/__main__.py
@@ -5,6 +5,7 @@ import logging
 import shutil
 from collections import defaultdict
 from contextlib import contextmanager
+from dataclasses import asdict
 from fnmatch import fnmatch
 from pathlib import Path
 from textwrap import indent, wrap
@@ -16,9 +17,11 @@ from packaging.version import parse
 from tabulate import tabulate
 
 from . import __version__
-from .app import AppVersion
+from .app import AppVersion, PEP508CompliantUrl
 from .app import _AiidaLabApp as AiidaLabApp
 from .config import AIIDALAB_APPS, AIIDALAB_REGISTRY
+from .fetch import fetch_from_url
+from .metadata import Metadata
 from .utils import load_app_registry_index
 from .utils import parse_app_repo as parse_app_repository
 
@@ -162,8 +165,16 @@ def _parse_requirement(app_requirement):
     try:
         return Requirement(app_requirement)
     except InvalidRequirement as error:
+        from urllib.parse import urlsplit
+
+        if urlsplit(app_requirement).scheme and "@" not in app_requirement:
+            raise click.ClickException(
+                "It looks like you tried to install directly from a PEP 508 "
+                "compliant URL. Make sure to use the 'app-name @ url' syntax "
+                "to provide a name for the app."
+            )
         raise click.ClickException(
-            f"Invalid requirement '{app_requirement}': {error!s}"
+            f"Invalid requirement '{app_requirement}': {error!s}\n"
         )
 
 
@@ -276,8 +287,27 @@ def show_environment(app_requirement, indent):
 
 
 def _find_version_to_install(
-    app_requirement, app, force, dependencies, python_bin, prereleases
+    app_requirement, force, dependencies, python_bin, prereleases
 ):
+    if app_requirement.url is not None:
+        with fetch_from_url(app_requirement.url) as repo:
+            metadata = Metadata.parse(repo)
+            registry_entry = dict(name=app_requirement.name, metadata=asdict(metadata))
+            app = AiidaLabApp.from_id(
+                app_requirement.name, registry_entry=registry_entry
+            )
+            if not (force or (dependencies in ("install", "ignore"))):
+                raise click.ClickException(
+                    f"Unable to check compatibility for {app_requirement} prior to installation."
+                )
+
+        if force or not app.is_installed():
+            return app, PEP508CompliantUrl(app_requirement.url)
+        else:
+            return app, None
+
+    app = _find_registered_app_from_id(app_requirement.name)
+
     assert dependencies in ("install", "require", "ignore")
     matching_releases = app.find_matching_releases(
         app_requirement.specifier, prereleases
@@ -365,13 +395,15 @@ def install(
     Install the 'hello-world' app with the latest version that matches the specification '>=1.0':
 
         install hello-world>=1.0
-    """
 
+    Install the 'hello-world' app directly from a PEP 508 compliant URL:
+
+        install hello-world@git+https://github.com/aiidalab/aiidalab-hello-world.git
+    """
     with _spinner_with_message("Collecting apps matching requirements... "):
         install_candidates = {
             requirement: _find_version_to_install(
                 requirement,
-                _find_registered_app_from_id(requirement.name),
                 dependencies=dependencies,
                 force=force,
                 python_bin=python_bin,

--- a/aiidalab/__main__.py
+++ b/aiidalab/__main__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Module that implements a basic command line interface (CLI) for AiiDAlab."""
-
 import json
+import logging
 import shutil
 from collections import defaultdict
 from contextlib import contextmanager
@@ -20,6 +20,10 @@ from .app import AppVersion
 from .app import _AiidaLabApp as AiidaLabApp
 from .config import AIIDALAB_APPS, AIIDALAB_REGISTRY
 from .utils import load_app_registry_index
+from .utils import parse_app_repo as parse_app_repository
+
+logging.basicConfig(level=logging.INFO)
+
 
 ICON_DETACHED = "\U000025AC"  # ▬
 ICON_MODIFIED = "\U00002022"  # •
@@ -176,6 +180,41 @@ def _find_app_and_releases(app_requirement):
     app = _find_app_from_id(app_requirement.name)
     matching_releases = app.find_matching_releases(app_requirement.specifier)
     return app, matching_releases
+
+
+@cli.command()
+@click.argument("repository")
+def parse_app_repo(repository):
+    """Parse an app repo for metadata and other information.
+
+    Use this command to parse a local or remote app repository for the app
+    metadata and environment specification.
+
+    Examples:
+
+    For a local app repository, provide the absolute or relative path:
+
+        parse-app-repo /path/to/aiidalab-hello-world
+
+    For a remote app repository, provide a PEP 508 compliant URL, for example:
+
+        parse-app-repo git+https://github.com/aiidalab/aiidalab-hello-world.git@v1.0.0
+    """
+    click.echo(f"Parsing {repository} ...", err=True)
+    try:
+        click.echo(json.dumps(parse_app_repository(repository)))
+    except ValueError as error:
+        click.secho(
+            f"Failed to parse metadata from '{repository}': {error!s}",
+            err=True,
+            fg="red",
+        )
+    except TypeError as error:
+        click.secho(
+            f"Failed to parse metadata from '{repository}': {error!s}",
+            err=True,
+            fg="red",
+        )
 
 
 @cli.command()

--- a/aiidalab/__main__.py
+++ b/aiidalab/__main__.py
@@ -171,12 +171,12 @@ def _find_registered_app_from_id(name):
     """Find app for a given requirement."""
     try:
         app = AiidaLabApp.from_id(name)
-        if app.releases is None:
+        if app.is_registered:
+            return app
+        else:
             raise click.ClickException(
-                f"Unable to identify releases for app '{name}'. App was likely "
-                "installed locally and/or is not registered."
+                f"App '{app}' was installed locally and/or is not registered."
             )
-        return app
     except KeyError:
         raise click.ClickException(f"Did not find entry for app with name '{name}'.")
 

--- a/aiidalab/__main__.py
+++ b/aiidalab/__main__.py
@@ -209,13 +209,7 @@ def parse_app_repo(repository):
     click.echo(f"Parsing {repository} ...", err=True)
     try:
         click.echo(json.dumps(parse_app_repository(repository)))
-    except ValueError as error:
-        click.secho(
-            f"Failed to parse metadata from '{repository}': {error!s}",
-            err=True,
-            fg="red",
-        )
-    except TypeError as error:
+    except (ValueError, TypeError) as error:
         click.secho(
             f"Failed to parse metadata from '{repository}': {error!s}",
             err=True,

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -95,9 +95,10 @@ class _AiidaLabApp:
             }
             return cls._migrate_registry_entry_to_v1(entry)
         except TypeError:
+            logger.warning(f"Unable to parse metadata from '{path}'")
             return {
-                "name": None,
-                "metadata": None,
+                "name": path.stem,
+                "metadata": dict(title=path.stem, description=""),
                 "releases": None,
                 "logo": None,
                 "categories": None,

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -95,7 +95,7 @@ class _AiidaLabApp:
             }
             return cls._migrate_registry_entry_to_v1(entry)
         except TypeError:
-            logger.warning(f"Unable to parse metadata from '{path}'")
+            logger.debug(f"Unable to parse metadata from '{path}'")
             return {
                 "name": path.stem,
                 "metadata": dict(title=path.stem, description=""),

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -119,6 +119,10 @@ class _AiidaLabApp:
         return cls.from_registry_entry(path=app_path, registry_entry=registry_entry)
 
     @property
+    def is_registered(self):
+        return self.releases is not None
+
+    @property
     def _repo(self):
         try:
             return Repo(str(self.path))
@@ -129,7 +133,7 @@ class _AiidaLabApp:
         if self._repo:
             if self.dirty():
                 return AppVersion.UNKNOWN
-            elif self.releases is None:
+            elif not self.is_registered:
                 return self.metadata.get("version", AppVersion.UNKNOWN)
             else:
                 try:
@@ -193,7 +197,7 @@ class _AiidaLabApp:
         if python_bin is None:
             python_bin = sys.executable
 
-        if self.releases is None:
+        if not self.is_registered:
             assert version == self.installed_version()
             environment = asdict(Environment.scan(self.path))
         else:
@@ -592,7 +596,7 @@ class AiidaLabApp(traitlets.HasTraits):
             and parse(self.installed_version).is_prerelease
         )
 
-        if self._app.releases is None:
+        if not self._app.is_registered:
             self.available_versions = [self.installed_version]
         else:
             all_available_versions = sorted(self._app.releases, key=parse, reverse=True)

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -58,6 +58,10 @@ class AppVersion(Enum):
     NOT_INSTALLED = auto()
 
 
+class PEP508CompliantUrl(str):
+    pass
+
+
 @dataclass
 class _AiidaLabApp:
 
@@ -276,9 +280,13 @@ class _AiidaLabApp:
         if python_bin is None:
             python_bin = sys.executable
 
+        if isinstance(version, PEP508CompliantUrl):
+            url = version
+        else:
+            url = self.releases[version]["url"]
+
         trash_path = self._move_to_trash()
 
-        url = self.releases[version]["url"]
         try:
             with fetch_from_url(url) as repo:
                 self._install_from_path(Path(repo))

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -130,11 +130,9 @@ class _AiidaLabApp:
             return None
 
     def installed_version(self):
-        if self._repo:
+        if self._repo and self.is_registered:
             if self.dirty():
                 return AppVersion.UNKNOWN
-            elif not self.is_registered:
-                return self.metadata.get("version", AppVersion.UNKNOWN)
             else:
                 try:
                     head_commit = self._repo.head().decode()

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -148,7 +148,7 @@ class _AiidaLabApp:
                     )
                     return AppVersion.UNKNOWN
         elif self.path.exists():
-            return AppVersion.UNKNOWN
+            return self.metadata.get("version", AppVersion.UNKNOWN)
         return AppVersion.NOT_INSTALLED
 
     def dirty(self):

--- a/aiidalab/environment.py
+++ b/aiidalab/environment.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+"""App environment specification
+
+The specification is used to describe a reproducible environment for a
+specific app, similar to the Reproducible Environment Specification (REES) [1]
+
+[1] https://repo2docker.readthedocs.io/en/latest/specification.html
+
+The following configuration files are recognized with the order of precedence
+matching the order shown here:
+
+.. glossary::
+
+    setup.cfg
+        Requirements listed as part of the [options]/install_requires field are
+        parsed as pip-installable Python requirements for this app.
+
+    requirements.txt
+        Requirements listed within this file are parsed as pip-installable
+        Python requirements for this app unless already parsed from the
+        setup.cfg file.
+
+"""
+from configparser import ConfigParser
+from dataclasses import dataclass, field
+from typing import List
+
+__all__ = [
+    "Environment",
+]
+
+
+@dataclass
+class Environment:
+    """App environment specification.
+
+    This dataclass contains the specification of an app environment and can be
+    used to scan an existing environment configuration from a given path and to
+    detect whether a given environment is meeting the specification.
+    """
+
+    python_requirements: List[str] = field(default_factory=list)
+
+    _FILES = ("requirements.txt",)
+
+    @staticmethod
+    def _scan(path):
+        def _parse_reqs(requirements):
+            for line in (line.strip() for line in requirements.splitlines()):
+                if line and not line.startswith("#"):
+                    yield line
+
+        def _parse_setup_cfg(setup_cfg):
+            cfg = ConfigParser()
+            cfg.read_string(setup_cfg)
+            return cfg["options"].get("install_requires", [])
+
+        # Parse the setup.cfg file (if present).
+        try:
+            yield "python_requirements", list(
+                _parse_reqs(_parse_setup_cfg(path.joinpath("setup.cfg").read_text()))
+            )
+        except (FileNotFoundError, KeyError):
+            # Parse the requirements.txt file (if present).
+            try:
+                yield "python_requirements", list(
+                    _parse_reqs(path.joinpath("requirements.txt").read_text())
+                )
+            except FileNotFoundError:
+                pass
+
+    @classmethod
+    def scan(cls, root):
+        """Scan the root path and determine the environment specification."""
+        return cls(**dict(cls._scan(root)))

--- a/aiidalab/fetch.py
+++ b/aiidalab/fetch.py
@@ -1,0 +1,105 @@
+import tarfile
+import tempfile
+from contextlib import contextmanager
+from io import BytesIO
+from pathlib import Path
+from urllib.parse import urldefrag, urlsplit, urlunsplit
+
+import dulwich
+import requests
+
+from .git_util import GitPath, GitRepo
+
+
+def _this_or_only_subdir(path):
+    members = list(path.iterdir())
+    return members[0] if len(members) == 1 and members[0].is_dir() else path
+
+
+@contextmanager
+def _fetch_from_path(path):
+    if path.is_dir():
+        yield path
+    else:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with tarfile.open(fileobj=BytesIO(path.read_bytes())) as tar_file:
+                tar_file.extractall(path=tmp_dir)
+                yield _this_or_only_subdir(Path(tmp_dir))
+
+
+@contextmanager
+def _fetch_from_https(url):
+    response = requests.get(url, stream=True)
+    response.raise_for_status()
+    content = response.content
+    with tempfile.NamedTemporaryFile() as tmp_file:
+        tmp_file.write(content)
+        tmp_file.flush()
+        with _fetch_from_path(Path(tmp_file.name)) as path:
+            yield path
+
+
+def _parse_git_url(git_url):
+    path = urldefrag(git_url).fragment
+    if "@" in git_url:
+        url, rev = urldefrag(git_url).url.rsplit("@", 1)
+    else:
+        url, rev = urldefrag(git_url).url, None
+    return url, (rev or "HEAD"), path
+
+
+@contextmanager
+def _fetch_from_git_https(git_url):
+    url, rev, path = _parse_git_url(git_url)
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        repo = GitRepo.clone_from_url(url, tmp_dir)
+        git_path = GitPath(repo.path, repo.ref_from_rev(rev)).joinpath(path)
+        with _fetch_from_path(git_path) as path:
+            yield path
+
+
+@contextmanager
+def _fetch_from_git_local(git_url):
+    url, rev, path = _parse_git_url(git_url)
+
+    try:
+        repo = GitRepo(urlsplit(url).path)
+    except dulwich.errors.NotGitRepository as error:
+        raise RuntimeError(
+            f"{error}"
+            + (" Did you use a relative path?" if urlsplit(url).netloc else "")
+        )
+
+    git_path = GitPath(repo.path, repo.ref_from_rev(rev)).joinpath(path)
+    with _fetch_from_path(git_path) as path:
+        yield path
+
+
+@contextmanager
+def fetch_from_url(url):
+    ps = urlsplit(url)
+
+    if ps.scheme in ("", "file"):  # on the local file system
+        try:
+            with _fetch_from_path(Path(ps.path)) as path:
+                yield path
+        except FileNotFoundError as error:
+            raise RuntimeError(
+                f"{error}" + (" Did you use a relative path?" if ps.netloc else "")
+            )
+
+    elif ps.scheme == "https":  # access archive via https
+        with _fetch_from_https(url) as path:
+            yield path
+
+    elif ps.scheme == "git+https":  # clone git repository via https
+        with _fetch_from_git_https(urlunsplit(ps._replace(scheme="https"))) as path:
+            yield path
+
+    elif ps.scheme == "git+file":  # parse local git repository
+        with _fetch_from_git_local(urlunsplit(ps._replace(scheme=""))) as path:
+            yield path
+
+    else:  # unknown scheme
+        raise ValueError(f"Unsupported scheme: {ps.scheme}.")

--- a/aiidalab/git_util.py
+++ b/aiidalab/git_util.py
@@ -1,8 +1,13 @@
 # -*- coding: utf-8 -*-
 """Utility module for git-managed AiiDAlab apps."""
+import locale
+import os
 import re
+from dataclasses import dataclass
 from enum import Enum
+from pathlib import Path
 from subprocess import CalledProcessError, run
+from urllib.parse import urldefrag
 
 from dulwich.porcelain import branch_list, status
 from dulwich.repo import Repo
@@ -112,3 +117,160 @@ def git_clone(url, commit, path):
         )
     except CalledProcessError as error:
         raise RuntimeError(error.stderr)
+
+
+@dataclass
+class GitPath(os.PathLike):
+    """Utility class to operate on git objects like path objects."""
+
+    repo: Path
+    commit: str
+    path: Path = Path(".")
+
+    def __fspath__(self):
+        return str(Path(self.repo).joinpath(self.path))
+
+    def joinpath(self, *other):
+        return type(self)(
+            repo=self.repo, path=self.path.joinpath(*other), commit=self.commit
+        )
+
+    def resolve(self, strict=False):
+        return type(self)(
+            repo=self.repo,
+            path=Path(self.repo)
+            .joinpath(self.path)
+            .resolve(strict=strict)
+            .relative_to(Path(self.repo).resolve()),
+            commit=self.commit,
+        )
+
+    def _get_type(self):
+        # Git expects that a current directory path ("." or "./") is
+        # represented with a trailing slash for this function.
+        path = "./" if self.path == Path() else self.path
+
+        try:
+            return (
+                run(
+                    ["git", "cat-file", "-t", f"{self.commit}:{path}"],
+                    cwd=self.repo,
+                    check=True,
+                    capture_output=True,
+                )
+                .stdout.decode(errors="ignore")
+                .strip()
+            )
+        except CalledProcessError as error:
+            if error.returncode == 128:
+                return None
+            raise
+
+    def is_file(self):
+        return self._get_type() == "blob"
+
+    def is_dir(self):
+        return self._get_type() == "tree"
+
+    def read_bytes(self):
+        try:
+            return run(
+                ["git", "show", f"{self.commit}:{self.path}"],
+                cwd=os.fspath(self.repo),
+                check=True,
+                capture_output=True,
+            ).stdout
+        except CalledProcessError as error:
+            error_message = error.stderr.decode(errors="ignore").strip()
+            if re.match(
+                f"fatal: Path '{re.escape(str(self.path))}' (exists on disk, but not in|does not exist)",
+                error_message,
+                flags=re.IGNORECASE,
+            ):
+                raise FileNotFoundError(f"{self.commit}:{self.path}")
+            elif re.match(
+                "fatal: Invalid object name", error_message, flags=re.IGNORECASE
+            ):
+                raise ValueError(f"Unknown commit: {self.commit}")
+            else:
+                raise  # unexpected error
+
+    def read_text(self, encoding=None, errors=None):
+        if encoding is None:
+            encoding = locale.getpreferredencoding(False)
+        if errors is None:
+            errors = "strict"
+        return self.read_bytes().decode(encoding=encoding, errors=errors)
+
+
+class GitRepo(Repo):
+    def get_current_branch(self):
+        try:
+            branch = run(
+                ["git", "branch", "--show-current"],
+                cwd=Path(self.path),
+                check=True,
+                capture_output=True,
+                encoding="utf-8",
+            ).stdout
+        except CalledProcessError as error:
+            if error.returncode == 129:
+                raise RuntimeError("This function equires at least git version 2.22.")
+            raise
+        if not branch:
+            raise RuntimeError(
+                "Unable to determine current branch name, likely in detached HEAD state."
+            )
+        return branch.strip()
+
+    def get_commit_for_tag(self, tag):
+        return self.get_peeled(f"refs/tags/{tag}".encode()).decode()
+
+    def get_merged_tags(self, branch):
+        for branch_ref in [f"refs/heads/{branch}", f"refs/remotes/origin/{branch}"]:
+            if branch_ref.encode() in self.refs:
+                yield from run(
+                    ["git", "tag", "--merged", branch_ref],
+                    cwd=self.path,
+                    check=True,
+                    capture_output=True,
+                    encoding="utf-8",
+                ).stdout.splitlines()
+                break
+        else:
+            raise ValueError(f"Not a branch: {branch}")
+
+    def rev_list(self, rev_selection):
+        return run(
+            ["git", "rev-list", rev_selection],
+            cwd=self.path,
+            check=True,
+            encoding="utf-8",
+            capture_output=True,
+        ).stdout.splitlines()
+
+    def ref_from_rev(self, rev):
+        """Determine ref from rev.
+
+        Returns branch reference if a branch with that name exists, otherwise a
+        tag reference, otherwise the rev itself (assuming it is a commit id).
+        """
+
+        if f"refs/heads/{rev}".encode() in self.refs:
+            return f"refs/heads/{rev}"
+        elif f"refs/remotes/origin/{rev}".encode() in self.refs:
+            return f"refs/remotes/origin/{rev}"
+        elif f"refs/tags/{rev}".encode() in self.refs:
+            return f"refs/tags/{rev}"
+        else:
+            return rev
+
+    @classmethod
+    def clone_from_url(cls, url, path):
+        run(
+            ["git", "clone", urldefrag(url).url, path],
+            cwd=Path(path).parent,
+            check=True,
+            capture_output=True,
+        )
+        return GitRepo(path)

--- a/aiidalab/metadata.py
+++ b/aiidalab/metadata.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+"""App metadata specification"""
+from configparser import ConfigParser
+from dataclasses import dataclass, field
+from typing import List
+
+__all__ = [
+    "Metadata",
+]
+
+
+def _map_development_state(classifiers):
+    "Map standard trove classifiers (PEP 301) to aiidalab development states."
+    if "Development Status :: 1 - Planning" in classifiers:
+        return "registered"
+    elif "Development Status :: 5 - Production/Stable" in classifiers:
+        return "stable"
+    elif any(
+        classifier in classifiers
+        for classifier in (
+            "Development Status :: 2 - Pre-Alpha",
+            "Development Status :: 3 - Alpha",
+            "development" "Development Status :: 4 - Beta",
+        )
+    ):
+        return "development"
+
+
+def _parse_config_dict(dict_):
+    "Parse a config dict string for key-values pairs."
+    for line in dict_.splitlines():
+        if line:
+            key, value = line.split("=")
+            yield key.strip(), value.strip()
+
+
+def _parse_setup_cfg(setup_cfg):
+    "Parse a setup.cfg configuration file string for metadata."
+    cfg = ConfigParser()
+    cfg.read_string(setup_cfg)
+
+    try:
+        metadata_pep426 = cfg["metadata"]
+    except KeyError:
+        metadata_pep426 = dict()
+    aiidalab = cfg["aiidalab"] if "aiidalab" in cfg else dict()
+
+    yield "title", aiidalab.get("title", metadata_pep426.get("name"))
+    yield "version", aiidalab.get("version", metadata_pep426.get("version"))
+    yield "description", aiidalab.get("description", metadata_pep426.get("description"))
+    yield "authors", aiidalab.get("authors", metadata_pep426.get("author"))
+    yield "external_url", aiidalab.get("external_url", metadata_pep426.get("url"))
+
+    project_urls = dict(_parse_config_dict(metadata_pep426.get("project_urls", "")))
+    yield "documentation_url", aiidalab.get(
+        "documentation_url",
+        project_urls.get("Documentation") or project_urls.get("documentation"),
+    )
+    yield "logo", aiidalab.get(
+        "logo", project_urls.get("Logo") or project_urls.get("logo")
+    )
+    yield "state", aiidalab.get(
+        "state", _map_development_state(metadata_pep426.get("classifiers", []))
+    )
+
+    yield "categories", aiidalab.get("categories", [])
+
+
+@dataclass
+class Metadata:
+    """App metadata specification."""
+
+    title: str
+    description: str
+    authors: str = None
+    state: str = None
+    documentation_url: str = None
+    external_url: str = None
+    logo: str = None
+    categories: List[str] = field(default_factory=list)
+    version: str = None
+
+    @staticmethod
+    def _parse(path):
+
+        try:
+            return {
+                key: value
+                for key, value in _parse_setup_cfg(
+                    path.joinpath("setup.cfg").read_text()
+                )
+                if value is not None
+            }
+        except FileNotFoundError:
+            return {}
+
+    @classmethod
+    def parse(cls, root):
+        """Parse the app metadata from a setup.cfg within the app repository.
+
+        This function will parse metadata fields from a possible "aiidalab"
+        section, but falls back to the standard fields defined as part of the
+        PEP 426-compliant metadata section for any missing values.
+        """
+        return cls(**dict(cls._parse(root)))

--- a/aiidalab/utils.py
+++ b/aiidalab/utils.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import time
 from collections import defaultdict
+from dataclasses import asdict
 from functools import wraps
 from pathlib import Path
 from subprocess import run
@@ -17,6 +18,9 @@ from cachetools import TTLCache, cached
 from packaging.utils import canonicalize_name
 
 from .config import AIIDALAB_REGISTRY
+from .environment import Environment
+from .fetch import fetch_from_url
+from .metadata import Metadata
 
 logger = logging.getLogger(__name__)
 FIND_INSTALLED_PACKAGES_CACHE = TTLCache(maxsize=32, ttl=60)
@@ -62,8 +66,38 @@ def load_app_registry_entry(app_id):
     try:
         return requests.get(f"{AIIDALAB_REGISTRY}/apps/{app_id}.json").json()
     except (ValueError, requests.ConnectionError):
-        print(f"Unable to load registry entry for app with id '{app_id}'.")
+        logger.debug(f"Unable to load registry entry for app with id '{app_id}'.")
         return None
+
+
+def parse_app_repo(repository, search_dirs=None):
+    """Parse an app repo for metadata and other information.
+
+    Use this function to parse a local or remote app repository for the app
+    metadata and environment specification.
+
+    Examples:
+
+    For a local app repository, provide the absolute or relative path:
+
+        repository="/path/to/aiidalab-hello-world"
+
+    For a remote app repository, provide a PEP 508 compliant URL, for example:
+
+        repository="git+https://github.com/aiidalab/aiidalab-hello-world.git@v1.0.0"
+    """
+    if search_dirs is None:
+        search_dirs = [".aiidalab/", "./"]
+
+    with fetch_from_url(repository) as repo:
+        for path in (repo.joinpath(dir_) for dir_ in search_dirs):
+            if path.is_dir():
+                metadata = Metadata.parse(path)
+                environment = Environment.scan(path)
+                return {
+                    "metadata": asdict(metadata),
+                    "environment": asdict(environment),
+                }
 
 
 class throttled:  # pylint: disable=invalid-name

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ install_requires =
     dulwich~=0.20.15
     ipython~=7.0
     packaging>=20.1
+    requests~=2.24.0
     requests-cache~=0.5.2
     tabulate~=0.8.9
     toml~=0.10


### PR DESCRIPTION
- Enables the local installation of non-registered apps.
- Local metadata used as fallback in cases where the registry cannot be
reached.
- Adds the 'parse-app-repo' aiidalab command that shows what metadata
and environment specification is parsed from a repository.