### PR TITLE
Distinguish between non-registered and registry cannot be reached.

### DIFF
--- a/aiidalab/__main__.py
+++ b/aiidalab/__main__.py
@@ -108,7 +108,10 @@ def search(app_query, prereleases):
         try:
             app_requirements = [Requirement(app_query)]
         except InvalidRequirement:  # interpreted as general search query
-            registry = load_app_registry_index()
+            try:
+                registry = load_app_registry_index()
+            except RuntimeError as error:
+                raise click.ClickException(error)
             app_requirements = [
                 Requirement(app_name)
                 for app_name in registry["apps"].keys()

--- a/aiidalab/utils.py
+++ b/aiidalab/utils.py
@@ -56,9 +56,8 @@ def load_app_registry_index():
     """Load apps' information from the AiiDAlab registry."""
     try:
         return requests.get(f"{AIIDALAB_REGISTRY}/apps_index.json").json()
-    except (ValueError, requests.ConnectionError):
-        print("Registry server is unavailable! Can't check for the updates")
-        return dict(apps=dict(), catgories=dict())
+    except (ValueError, requests.ConnectionError) as error:
+        raise RuntimeError(f"Unable to load registry index: '{error}'")
 
 
 def load_app_registry_entry(app_id):


### PR DESCRIPTION
 - The state where the registry cannot be reached and where an app is
not registered are clearly distinguished. It should be noted that when
the registry cannot be reached, it is not possible to determine whether
an app is hypothetically registered or not.
 - Replace `updates_available` trait with `remote_update_status`.
   To support more than three states.
 - Refactor version determination.

Fixes #221.