### PR TITLE
Update the location of apps logo and categories.

### DIFF
--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -90,12 +90,11 @@ class _AiidaLabApp:
     @classmethod
     def _registry_entry_from_path(cls, path):
         try:
-            entry = {
+            return {
                 "name": path.stem,
                 "metadata": asdict(Metadata.parse(path)),
                 "releases": None,
             }
-            return entry
         except TypeError:
             logger.debug(f"Unable to parse metadata from '{path}'")
             return {


### PR DESCRIPTION
fixes #239 

In the updated version of the registry the logo and categories
are placed under metadata.