### PR TITLE
Dependencies: Pin MarkupSafe.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ packages = find:
 install_requires =
     CacheControl~=0.12.6
     Jinja2~=2.11.3
+    MarkupSafe==2.0.1
     cachetools~=4.1
     click~=7.0
     click-spinner~=0.1.10


### PR DESCRIPTION
To workaround incompatibility (https://github.com/pallets/jinja/issues/1587).