### PR TITLE
Fix to order of parameters and image name  in `docker run` line

### DIFF
--- a/docs/source/usage/index.rst
+++ b/docs/source/usage/index.rst
@@ -22,7 +22,7 @@ AiiDAlab launch
 To run AiiDAlab on your own workstation or laptop you can either
 
  - *(recommended)* Use the :ref:`aiidalab-launch <usage:aiidalab-launch>` tool which is a thin docker wrapper, or
- - run the image directly with: ```docker run aiidalab-docker-stack -p 8888:8888```.
+ - run the image directly with: ```docker run -p 8888:8888 aiidalab/aiidalab-docker-stack```.
 
 To use **AiiDAlab launch** you will have to
 


### PR DESCRIPTION
This PR fixes the following issues: 
 - The ```-p 8888:8888``` should be before the name of the image (otherwise it is passed as a command to the image instead of as a parameter to docker).
 - The default image name when pulling from dockerhub is ```aiidalab/aiidalab-docker-stack```