### PR TITLE
Check forked process calls for success during app installation.

### DIFF
--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -270,6 +270,8 @@ class _AiidaLabApp:
             process = run_pip_install(*args, python_bin=python_bin)
             for line in io.TextIOWrapper(process.stdout, encoding="utf-8"):
                 stdout.write(line)
+            if process.returncode != 0:
+                raise RuntimeError("Failed to install dependencies.")
 
             # AiiDA plugins require reentry run to be found by AiiDA.
             process = run_reentry_scan()
@@ -280,6 +282,8 @@ class _AiidaLabApp:
             process = run_verdi_daemon_restart()
             for line in io.TextIOWrapper(process.stdout, encoding="utf-8"):
                 stdout.write(line)
+            if process.returncode != 0:
+                raise RuntimeError("Failed to restart verdi daemon.")
 
         for path in (self.path.joinpath(".aiidalab"), self.path):
             if path.exists():
@@ -312,7 +316,8 @@ class _AiidaLabApp:
             # detachment of child processes. For example, an app might trigger
             # a background process that is supposed to finish after the
             # installation is technically completed.
-            run_post_install_script(post_install_file)
+            if run_post_install_script(post_install_file).returncode != 0:
+                raise CalledProcessError
 
     def _install_from_path(self, path):
         if path.is_dir():

--- a/aiidalab/utils.py
+++ b/aiidalab/utils.py
@@ -201,7 +201,6 @@ def this_or_only_subdir(path):
 def run_pip_install(*args, python_bin=sys.executable):
     return subprocess.Popen(
         [python_bin, "-m", "pip", "install", *args],
-        bufsize=1,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
     )
@@ -219,7 +218,6 @@ def run_reentry_scan():
 def run_verdi_daemon_restart():
     return subprocess.Popen(
         ["verdi", "daemon", "restart"],
-        bufsize=1,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
     )


### PR DESCRIPTION
Check the exit code of forked subprocess to ensure that issues actually propagate up
and that the installation process does not simply proceed despite errors, e.g., during
the installation of dependencies.