### PR TITLE
Better error if logo/categories metadata are missing

### DIFF
--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -585,8 +585,16 @@ class AiidaLabApp(traitlets.HasTraits):
         super().__init__()
 
         self.name = self._app.name
-        self.logo = self._app.metadata["logo"]
-        self.categories = self._app.metadata["categories"]
+
+        try:
+            self.logo = self._app.metadata["logo"]
+        except KeyError:
+            raise ValueError(f"Did not find logo in {self.name} metadata")
+        try:
+            self.categories = self._app.metadata["categories"]
+        except KeyError:
+            raise ValueError(f"Did not find categories in {self.name} metadata")
+
         self.is_installed = self._app.is_installed
         self.path = str(self._app.path)
         self.refresh_async()


### PR DESCRIPTION
I just lost an hour when trying to understand why the home app was throwing an error about a missing logo key, until I realized that I had an extra folder in the `apps/` folder. With this change I would have seen the issue immediately at least.