### PR TITLE
Fix: Add missing arguments to raised exception

### DIFF
--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -315,7 +315,7 @@ class _AiidaLabApp:
             process = run_post_install_script(post_install_file)
             process.wait()
             if process.returncode != 0:
-                raise CalledProcessError
+                raise CalledProcessError(process.returncode, str(post_install_file))
 
     def _install_from_path(self, path):
         if path.is_dir():


### PR DESCRIPTION
Before this change, if a  `post_install` script failed when installing an app we would get
```
raise CalledProcessError
TypeError: __init__() missing 2 required positional arguments: 'returncode' and 'cmd'
```

More info at:
https://docs.python.org/3/library/subprocess.html#subprocess.CalledProcessError