### PR TITLE
Install App dependencies to ~/.local, not /opt/conda

### DIFF
--- a/aiidalab/utils.py
+++ b/aiidalab/utils.py
@@ -200,7 +200,7 @@ def this_or_only_subdir(path):
 
 def run_pip_install(*args, python_bin=sys.executable):
     return subprocess.Popen(
-        [python_bin, "-m", "pip", "install", *args],
+        [python_bin, "-m", "pip", "install", "--user", *args],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
     )


### PR DESCRIPTION
In the old Docker stack image, the conda environment in /opt/conda was not writeable by the aiida user. As a side-effect of that, when the AiiDAlab app was installed via pip, its declared dependencies (and the app itself) was installed in the /home/aiida/.local directory. These dependencies were then persisted between different container invocation since they were stored in the home volume.

In the new full-stack image, the conda environment is writeable by the jovyan user, hence pip defaults to the system-wide installation, in this case /opt/conda. Therefore, the installed dependencies disappear when the container exits.
In the next invocation, the Apps won't load due to missing dependencies.

The fix is to explicitly instruct pip to do the user install into the ~/.local/ directory.

Closes #322

**TODO**
- [x] Test that the fix indeed work
- [x] Test the packages in `~/.local/` take precedence before packages in `/opt/conda` 