### PR TITLE
Support parsing categories from setup.cfg

### DIFF
--- a/aiidalab/metadata.py
+++ b/aiidalab/metadata.py
@@ -64,7 +64,12 @@ def _parse_setup_cfg(setup_cfg):
         "state", _map_development_state(metadata_pep426.get("classifiers", []))
     )
 
-    yield "categories", aiidalab.get("categories", [])
+    # Allow passing single category and convert to list
+    # and allow parse line separated string as list
+    categories = aiidalab.get("categories", [])
+    if isinstance(categories, str):
+        categories = [c for c in categories.split("\n") if c]
+    yield "categories", categories
 
 
 @dataclass


### PR DESCRIPTION
The `categories` provided in the metadata will be parsed as a string, but a list is required. 
It is now allowed to provide a single category that is parsed as a list. 
Or the list separated by newlines will be parsed as a list.

Closes #257 