### PR TITLE
Deps: Bump watchdog

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
     toml~=0.10
     traitlets~=5.0
     urllib3~=1.24
-    watchdog~=0.10
+    watchdog~=2.1
 python_requires = >=3.7
 include_package_data = True
 zip_safe = False


### PR DESCRIPTION
Watchdog dependency seems to be used for live monitoring of AiiDAlab app installation process (I didn't look too closely what it actually does though). The old version prevents upgrade to Python 3.10.

I checked the watchdog Changelog and it seems this should be a seamless update. I have manually tested installation from the Appstore on this branch and it seems to work. Would be good if somebody else with more experience with Appstore tested as well. You can use this image: `ghcr.io/aiidalab/full-stack:pr-337` Note that this image is build with Python 3.10, so you might as well test other things. :-) 