### PR TITLE
FIX: Change isAlive to is_alive

### DIFF
--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -481,7 +481,7 @@ class AiidaLabAppWatch:
         The ._observer thread is controlled by the ._monitor_thread.
         """
         assert os.path.isdir(self.app.path)
-        assert self._observer is None or not self._observer.isAlive()
+        assert self._observer is None or not self._observer.is_alive()
 
         event_handler = self.AppPathFileSystemEventHandler(self.app)
 
@@ -527,9 +527,9 @@ class AiidaLabAppWatch:
                         self.app.refresh()
 
                     if is_dir:
-                        if self._observer is None or not self._observer.isAlive():
+                        if self._observer is None or not self._observer.is_alive():
                             self._start_observer()
-                    elif self._observer and self._observer.isAlive():
+                    elif self._observer and self._observer.is_alive():
                         self._stop_observer()
 
                     sleep(1)


### PR DESCRIPTION
Method threading.Thread.isAlive has been removed in Python 3.9, https://bugs.python.org/issue37804

Closes #340

I don't have a capacity to actually test this, leaving up to the reviewers, sorry.