### PR TITLE
Using INSTALLED_FLAG for installed check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ Pipfile.lock
 requirements.txt_dev
 requirements.txt_stable
 .DS_Store
+.INSTALLED.FLAG

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
             args: [--count, --show-source, --statistics]
 
     - repo: https://github.com/pycqa/isort
-      rev: 5.11.4
+      rev: 5.12.0
       hooks:
           - id: isort
             args: [--profile, black, --filter-files]

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -75,6 +75,8 @@ class _AiidaLabApp:
     path: Path
     releases: dict = field(default_factory=dict)
 
+    _INSTALLED_FLAG = "INSTALLED.FLAG"
+
     @classmethod
     def from_registry_entry(cls, path, registry_entry):
         return cls(
@@ -166,8 +168,10 @@ class _AiidaLabApp:
             return self._repo.dirty()
 
     def is_installed(self):
-        """The app is installed if the corresponding folder is present."""
-        return self.path.exists()
+        """The app is installed if the corresponding flag file is present."""
+        installed_flag = self.path / self._INSTALLED_FLAG
+
+        return installed_flag.exists()
 
     def remote_update_status(self, prereleases=False):
         """Determine the remote update satus.
@@ -437,6 +441,9 @@ class _AiidaLabApp:
                     f"Failed to install '{self.name}' (version={version}) at '{self.path}'"
                     f", due to error: {error}"
                 )
+
+        else:
+            self.path.touch(self._INSTALLED_FLAG)
 
 
 class AppNotInstalledException(Exception):

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -49,6 +49,8 @@ from .utils import (
 
 logger = logging.getLogger(__name__)
 
+_INSTALLED_FLAG = ".INSTALLED.FLAG"
+
 
 # A version is usually of type str, but it can also be a value
 # of this Enum to indicate special app states in which the
@@ -74,8 +76,6 @@ class _AiidaLabApp:
     name: str
     path: Path
     releases: dict = field(default_factory=dict)
-
-    _INSTALLED_FLAG = "INSTALLED.FLAG"
 
     @classmethod
     def from_registry_entry(cls, path, registry_entry):
@@ -167,11 +167,13 @@ class _AiidaLabApp:
         if self._repo:
             return self._repo.dirty()
 
+    def _installed_flag(self):
+        """Return path to the file as installed flag"""
+        return self.path / _INSTALLED_FLAG
+
     def is_installed(self):
         """The app is installed if the corresponding flag file is present."""
-        installed_flag = self.path / self._INSTALLED_FLAG
-
-        return installed_flag.exists()
+        return self._installed_flag.exists()
 
     def remote_update_status(self, prereleases=False):
         """Determine the remote update satus.
@@ -443,7 +445,7 @@ class _AiidaLabApp:
                 )
 
         else:
-            self.path.touch(self._INSTALLED_FLAG)
+            self._installed_flag.touch()
 
 
 class AppNotInstalledException(Exception):


### PR DESCRIPTION
This is the root of the issue https://github.com/aiidalab/aiidalab-home/issues/100.
The `is_installed` check if the app is installed by checking the folder under `apps`. It is not enough since during the installing, the repo will be put in the path which make the `is_installed` fakely manifest that the app is installed. 
I implement a more strict check by putting a flag file in the app path. The flag is added only if the installed is complete without exception.

- [x] Problem that the Uninstalled button behavior is incorrect. When the app is installed the button is not activated.