### PR TITLE
Make the package compatible with old docker stack again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
 
         steps:
             - uses: actions/checkout@v2
-            - name: Set up Python 3.9
+            - name: Set up Python 3.8
               uses: actions/setup-python@v2
               with:
-                  python-version: 3.9
+                  python-version: 3.8
             - uses: pre-commit/action@v2.0.0
 
     test-package:
@@ -30,7 +30,7 @@ jobs:
 
             - uses: actions/setup-python@v2
               with:
-                  python-version: 3.9
+                  python-version: 3.7
 
             - name: Install package
               run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ jobs:
             - uses: actions/checkout@v2
               with:
                   fetch-depth: 0
-                  submodules: true
 
             - uses: actions/setup-python@v2
               with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 ---
-name: continuous-integration
+name: CI
 
 on: [push, pull_request]
 
@@ -11,10 +11,10 @@ jobs:
 
         steps:
             - uses: actions/checkout@v2
-            - name: Set up Python 3.8
+            - name: Set up Python 3.9
               uses: actions/setup-python@v2
               with:
-                  python-version: 3.8
+                  python-version: 3.9
             - uses: pre-commit/action@v2.0.0
 
     test-package:
@@ -30,7 +30,7 @@ jobs:
 
             - uses: actions/setup-python@v2
               with:
-                  python-version: 3.7
+                  python-version: 3.9
 
             - name: Install package
               run: |

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -41,6 +41,7 @@ from aiidalab.utils import (
     load_app_registry_index,
     run_pip_install,
     run_post_install_script,
+    run_reentry_scan,
     run_verdi_daemon_restart,
     split_git_url,
     this_or_only_subdir,
@@ -340,6 +341,11 @@ class _AiidaLabApp:
             process.wait()
             if process.returncode != 0:
                 raise RuntimeError("Failed to install dependencies.")
+
+            # AiiDA plugins require reentry run to be found by AiiDA.
+            process = run_reentry_scan()
+            for line in io.TextIOWrapper(process.stdout, encoding="utf-8"):
+                stdout.write(line)
 
             # Restarting the AiiDA daemon to import newly installed plugins.
             process = run_verdi_daemon_restart()

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -344,10 +344,10 @@ class _AiidaLabApp:
             # In practice this should never happen
             if installed_aiida is None:
                 return False
-            aiida1 = Requirement("aiida-core<2.0.0b1")
+            aiida_v1 = Requirement("aiida-core<2.0.0b1")
             # This is needed to handle pre-release versions such as 1.0.0b0
-            aiida1.specifier.prereleases = True
-            if installed_aiida.fulfills(aiida1):
+            aiida_v1.specifier.prereleases = True
+            if installed_aiida.fulfills(aiida_v1):
                 return True
             return False
 

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -356,6 +356,7 @@ class _AiidaLabApp:
             # https://www.endpoint.com/blog/2015/01/getting-realtime-output-using-python/
 
             # Install package dependencies.
+            stdout.write(f"Running 'pip install --user {' '.join(args)}'\n")
             process = run_pip_install(*args, python_bin=python_bin)
             for line in io.TextIOWrapper(process.stdout, encoding="utf-8"):
                 stdout.write(line)
@@ -365,14 +366,14 @@ class _AiidaLabApp:
 
             # AiiDA plugins require reentry run to be found by AiiDA.
             if _should_run_reentry():
-                stdout.write("Running 'reentry scan'")
+                stdout.write("\nRunning 'reentry scan'\n")
                 process = run_reentry_scan()
                 for line in io.TextIOWrapper(process.stdout, encoding="utf-8"):
                     stdout.write(line)
                 process.wait()
                 if process.returncode != 0:
                     # Let's not fail the install because of this, just emit a warning.
-                    logger.warning("WARNING: 'reentry scan' failed")
+                    logger.warning("'reentry scan' failed")
 
             # Restarting the AiiDA daemon to import newly installed plugins.
             process = run_verdi_daemon_restart()

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -327,7 +327,7 @@ class _AiidaLabApp:
             for name, requirement in unmatched_dependencies.items()
         ]
 
-    def _install_dependencies(self, python_bin, stdout=None):
+    def _install_dependencies(self, python_bin, stdout):
         """Try to install the app dependencies with pip (if specified)."""
 
         def _should_run_reentry():
@@ -340,7 +340,7 @@ class _AiidaLabApp:
             aiida1 = Requirement("aiida-core<2.0.0b1")
             # This is needed to handle pre-release versions such as 1.0.0b0
             aiida1.specifier.prereleases = True
-            if installed_aiida.fullfills(aiida1):
+            if installed_aiida.fulfills(aiida1):
                 return True
             return False
 
@@ -362,6 +362,10 @@ class _AiidaLabApp:
                 process = run_reentry_scan()
                 for line in io.TextIOWrapper(process.stdout, encoding="utf-8"):
                     stdout.write(line)
+                process.wait()
+                if process.returncode != 0:
+                    # Let's not fail the install because of this, just emit a warning.
+                    logger.warning("WARNING: 'reentry scan' failed")
 
             # Restarting the AiiDA daemon to import newly installed plugins.
             process = run_verdi_daemon_restart()
@@ -504,7 +508,7 @@ class _AiidaLabApp:
 
             # Install dependencies
             if install_dependencies:
-                self._install_dependencies(python_bin, stdout=stdout)
+                self._install_dependencies(python_bin, stdout)
 
             # Run post-installation triggers.
             if post_install_triggers:

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -337,9 +337,9 @@ class _AiidaLabApp:
             # In practice this should never happen
             if installed_aiida is None:
                 return False
-            # TODO: It seems that this requirement does not work for
-            # pre-releases (e.g. version 1.0b0 will not fullfill it)
-            aiida1 = Requirement("aiida-core<2")
+            aiida1 = Requirement("aiida-core<2.0.0b1")
+            # This is needed to handle pre-release versions such as 1.0.0b0
+            aiida1.specifier.prereleases = True
             if installed_aiida.fullfills(aiida1):
                 return True
             return False

--- a/aiidalab/utils.py
+++ b/aiidalab/utils.py
@@ -246,7 +246,6 @@ def run_pip_install(*args, python_bin=sys.executable):  # type: ignore
 def run_reentry_scan():  # type: ignore
     return subprocess.Popen(
         ["reentry", "scan"],
-        bufsize=1,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
     )

--- a/aiidalab/utils.py
+++ b/aiidalab/utils.py
@@ -239,6 +239,15 @@ def run_pip_install(*args, python_bin=sys.executable):
     )
 
 
+def run_reentry_scan():
+    return subprocess.Popen(
+        ["reentry", "scan"],
+        bufsize=1,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+
 def run_verdi_daemon_restart():
     return subprocess.Popen(
         ["verdi", "daemon", "restart"],

--- a/aiidalab/utils.py
+++ b/aiidalab/utils.py
@@ -166,7 +166,7 @@ class Package:
         return canonicalize_name(self._name)
 
     def fulfills(self, requirement):
-        """Returns True if this entry fullfills the requirement."""
+        """Returns True if this entry fulfills the requirement."""
         return self.canonical_name == canonicalize_name(requirement.name) and (
             self.version in requirement.specifier or self.version is None
         )

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,6 @@ install_requires =
     CacheControl~=0.12
     Jinja2>=2.11.3,<4
     MarkupSafe==2.0.1
-    aiida-core>=1.0.0,<3
     cachetools~=4.1
     click>=7.0,<9
     click-spinner~=0.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,6 @@ install_requires =
     CacheControl~=0.12
     Jinja2>=2.11.3,<4
     MarkupSafe==2.0.1
-    aiida-core>=2.0.0,<3
     cachetools~=4.1
     click>=7.0,<9
     click-spinner~=0.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ install_requires =
     CacheControl~=0.12
     Jinja2>=2.11.3,<4
     MarkupSafe==2.0.1
+    aiida-core>=1.0.0,<3
     cachetools~=4.1
     click>=7.0,<9
     click-spinner~=0.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,3 +26,23 @@ def generate_app():
         return app
 
     return _generate_app
+
+
+_MONKEYPATCHED_INSTALLED_PACKAGES = [
+    {"name": "aiida-core", "version": "2.2.1"},
+    {"name": "jupyter_client", "version": "7.3.5"},
+]
+
+
+@pytest.fixture
+def installed_packages(monkeypatch):
+    """change the return of pip_list.
+    This is to mimic the pip list command output, which returns a json string represent
+    the list of installed packages."""
+    from aiidalab.utils import FIND_INSTALLED_PACKAGES_CACHE
+
+    FIND_INSTALLED_PACKAGES_CACHE.clear()  # clear the cache
+    monkeypatch.setattr(
+        "aiidalab.utils._pip_list",
+        lambda _: _MONKEYPATCHED_INSTALLED_PACKAGES,
+    )

--- a/tests/test_appclass.py
+++ b/tests/test_appclass.py
@@ -1,7 +1,5 @@
-import aiida
 import pytest
 import traitlets
-from packaging import version
 
 from aiidalab.app import AiidaLabApp
 
@@ -28,9 +26,7 @@ def test_prereleases(generate_app):
     assert "v23.01.0b1" in app.available_versions
 
 
-@pytest.mark.skipif(
-    version.parse(aiida.__version__).major != 2, reason="only pass for aiida 2.x"
-)
+@pytest.mark.usefixtures("installed_packages")
 def test_dependencies(generate_app):
     app: AiidaLabApp = generate_app()
     app.refresh()

--- a/tests/test_appdataclass.py
+++ b/tests/test_appdataclass.py
@@ -8,25 +8,6 @@ from packaging.requirements import Requirement
 
 from aiidalab.app import _AiidaLabApp
 
-_MONKEYPATCHED_INSTALLED_PACKAGES = [
-    {"name": "aiida-core", "version": "2.2.1"},
-    {"name": "jupyter_client", "version": "7.3.5"},
-]
-
-
-@pytest.fixture
-def installed_packages(monkeypatch):
-    """change the return of pip_list.
-    This is to mimic the pip list command output, which returns a json string represent
-    the list of installed packages."""
-    from aiidalab.utils import FIND_INSTALLED_PACKAGES_CACHE
-
-    FIND_INSTALLED_PACKAGES_CACHE.clear()  # clear the cache
-    monkeypatch.setattr(
-        "aiidalab.utils._pip_list",
-        lambda _: _MONKEYPATCHED_INSTALLED_PACKAGES,
-    )
-
 
 @pytest.fixture
 def python_bin():


### PR DESCRIPTION
This PR essentially reverts some of the changes made in #301, which dropped support for the old Docker stack.
We reintroduce support by:

1. Detecting `aiida-core` version and running `reentry scan` only for AiiDA 1.x
2. Dropping dependency on `aiida-core` in setup.cfg. I don't really see a reason why this package should depend on aiida-core. This also makes local development easier since one does not need to have aiida-core in the dev environment. Also makes installation in our CI faster.

Closes #348 