### PR TITLE
add count to proper set busy traitlets

### DIFF
--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -8,6 +8,7 @@ import shutil
 import sys
 import tarfile
 import tempfile
+import threading
 from contextlib import contextmanager
 from dataclasses import asdict, dataclass, field
 from enum import Enum, Flag, auto
@@ -606,6 +607,7 @@ class AiidaLabApp(traitlets.HasTraits):
         self.name = self._app.name
 
         self._busy_count = 0
+        self._busy_count_lock = threading.Lock()
 
         try:
             self.logo = self._app.metadata["logo"]
@@ -654,11 +656,18 @@ class AiidaLabApp(traitlets.HasTraits):
     def _show_busy(self):
         """Apply this decorator to indicate that the app is busy during execution."""
         self.set_trait("busy", True)
-        self._busy_count += 1
+
+        # we need to use a lock here, because the busy trait is not thread-safe
+        # we may use _show_busy in different threads, e.g. when installing and auto-status refresh
+        with self._busy_count_lock:
+            self._busy_count += 1
+
         try:
             yield
         finally:
-            self._busy_count -= 1
+            with self._busy_count_lock:
+                self._busy_count -= 1
+
             if self._busy_count == 0:
                 self.set_trait("busy", False)
 

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -655,12 +655,11 @@ class AiidaLabApp(traitlets.HasTraits):
     @contextmanager
     def _show_busy(self):
         """Apply this decorator to indicate that the app is busy during execution."""
-        self.set_trait("busy", True)
-
         # we need to use a lock here, because the busy trait is not thread-safe
         # we may use _show_busy in different threads, e.g. when installing and auto-status refresh
         with self._busy_count_lock:
             self._busy_count += 1
+            self.set_trait("busy", True)
 
         try:
             yield
@@ -668,8 +667,8 @@ class AiidaLabApp(traitlets.HasTraits):
             with self._busy_count_lock:
                 self._busy_count -= 1
 
-            if self._busy_count == 0:
-                self.set_trait("busy", False)
+                if self._busy_count == 0:
+                    self.set_trait("busy", False)
 
     def in_category(self, category):
         # One should test what happens if the category won't be defined.

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -605,6 +605,8 @@ class AiidaLabApp(traitlets.HasTraits):
 
         self.name = self._app.name
 
+        self._busy_count = 0
+
         try:
             self.logo = self._app.metadata["logo"]
         except KeyError:
@@ -652,10 +654,13 @@ class AiidaLabApp(traitlets.HasTraits):
     def _show_busy(self):
         """Apply this decorator to indicate that the app is busy during execution."""
         self.set_trait("busy", True)
+        self._busy_count += 1
         try:
             yield
         finally:
-            self.set_trait("busy", False)
+            self._busy_count -= 1
+            if self._busy_count == 0:
+                self.set_trait("busy", False)
 
     def in_category(self, category):
         # One should test what happens if the category won't be defined.


### PR DESCRIPTION
This is the more direct cause of https://github.com/aiidalab/aiidalab-home/issues/100, rather than https://github.com/aiidalab/aiidalab/pull/349.
In the package, there is already a context manager `_show_busy` provide to hold the display before the operations are running. However, this context manager only set the `self.busy` to a bool, which will be overridden unexpectedly if the `_show_busy` is embedded in itself. This happened for `install_app`, `updata_app` and `uninstall_app`, they are supposed to use `_show_busy` to prevent information to be displayed, but inside these function also call `refresh` which have another `_show_busy`. I add a counter to properly set the `busy` traitlets. It is `False` (which means not busy) when it counts down to zero. 