### PR TITLE
watchdog file system check not trigger refresh on file opened

### DIFF
--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -27,7 +27,7 @@ import traitlets
 from dulwich.errors import NotGitRepository
 from packaging.requirements import Requirement
 from packaging.version import parse
-from watchdog.events import FileSystemEventHandler
+from watchdog.events import EVENT_TYPE_OPENED, FileSystemEventHandler
 from watchdog.observers import Observer
 from watchdog.observers.polling import PollingObserver
 
@@ -530,8 +530,9 @@ class AiidaLabAppWatch:
             self.app = app
 
         def on_any_event(self, event):
-            """Refresh app for any event."""
-            self.app.refresh_async()
+            """Refresh app for any event except opened."""
+            if event.event_type != EVENT_TYPE_OPENED:
+                self.app.refresh_async()
 
     def __init__(self, app):
         self.app = app

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
     toml~=0.10
     traitlets~=5.0
     urllib3~=1.24
-    watchdog~=2.1
+    watchdog~=2.3
 python_requires = >=3.7
 include_package_data = True
 zip_safe = False


### PR DESCRIPTION
fixes #358 

The watchdog file system monitor introduce a new event handler `INOPNED` for when file opened. The new "file opened" event is included by default in all events: https://github.com/gorakhargosh/watchdog/blob/v2.3.0/src/watchdog/events.py#L289

The details are discussed at https://github.com/gorakhargosh/watchdog/issues/949, we encounter the same issue. But we use `on_any_event` explicitly, we adopt the same change as https://github.com/gorakhargosh/watchdog/commit/25a2d1fec55fc32f97055ba827c8ce7b959acb34 to avoid spammed by the opened event update. 