### PR TITLE
Using event to log the stop status of the monitor threading

### DIFF
--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -660,14 +660,15 @@ class AiidaLabAppWatch:
         return self._monitor_thread and self._monitor_thread.is_alive()
 
     def join(self, timeout=None):
-        """Join the watch after stopping.
+        """Join the watch and observer after stopping.
 
         This function will timeout if a timeout argument is provided. Use the
         is_alive() function to determien whether the watch was stopped within
         the given timout.
         """
-        if self._monitor_thread is not None:
+        if self._monitor_thread is not None and self._observer is not None:
             self._monitor_thread.join(timeout=timeout)
+            self._observer.join(timeout=timeout)
 
 
 class AiidaLabApp(traitlets.HasTraits):  # type: ignore

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -540,7 +540,6 @@ class AiidaLabAppWatch:
         def on_any_event(self, event):
             """Refresh app for any event except opened."""
             if event.event_type != EVENT_TYPE_OPENED:
-                print(event)
                 self.app.refresh_async()
 
     def __init__(self, app):
@@ -599,11 +598,8 @@ class AiidaLabAppWatch:
 
             def check_path_exists_changed():
                 is_dir = os.path.isdir(self.app.path)
-                print("or this??", is_dir)
-                print("checking...")
                 while not self._monitor_thread_stop.is_set():
                     switched = is_dir != os.path.isdir(self.app.path)
-                    print("??", switched)
                     if switched:
                         # this is for when the app folder first time create or deleted
                         is_dir = not is_dir

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -540,6 +540,7 @@ class AiidaLabAppWatch:
         def on_any_event(self, event):
             """Refresh app for any event except opened."""
             if event.event_type != EVENT_TYPE_OPENED:
+                print(event)
                 self.app.refresh_async()
 
     def __init__(self, app):
@@ -598,9 +599,13 @@ class AiidaLabAppWatch:
 
             def check_path_exists_changed():
                 is_dir = os.path.isdir(self.app.path)
+                print("or this??", is_dir)
+                print("checking...")
                 while not self._monitor_thread_stop.is_set():
                     switched = is_dir != os.path.isdir(self.app.path)
+                    print("??", switched)
                     if switched:
+                        # this is for when the app folder first time create or deleted
                         is_dir = not is_dir
                         self.app.refresh()
 

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -666,8 +666,9 @@ class AiidaLabAppWatch:
         is_alive() function to determien whether the watch was stopped within
         the given timout.
         """
-        if self._monitor_thread is not None and self._observer is not None:
+        if self._monitor_thread is not None:
             self._monitor_thread.join(timeout=timeout)
+        if self._observer is not None:
             self._observer.join(timeout=timeout)
 
 

--- a/tests/test_appclass.py
+++ b/tests/test_appclass.py
@@ -68,6 +68,8 @@ def test_app_watch(tmp_path):
     app_watch.stop()
     app_watch.join()
 
+    assert app_watch.is_alive() is False
+    assert app_watch._observer.is_alive() is False
     assert app.x == 4
 
     # The stop of watch monitor thread will trigger stop of observer's thread.

--- a/tests/test_appclass.py
+++ b/tests/test_appclass.py
@@ -52,9 +52,6 @@ def test_app_watch(tmp_path):
         def refresh_async(self):
             self.x += 1
 
-        def refresh(self):
-            pass
-
     app = DummyApp(path=Path(tmp_path))
     app_watch = AiidaLabAppWatch(app)
     app_watch.start()
@@ -73,7 +70,7 @@ def test_app_watch(tmp_path):
 
     assert app.x == 4
 
-    # The stop of watch monitor thread will trigger stop of observer's thread. 
+    # The stop of watch monitor thread will trigger stop of observer's thread.
     # After the observer is stopped, file system events should no longer trigger `refresh_async`
     testfile = tmp_path / "test1"
     testfile.touch()

--- a/tests/test_appclass.py
+++ b/tests/test_appclass.py
@@ -1,3 +1,4 @@
+import threading
 from dataclasses import dataclass
 from pathlib import Path
 from time import sleep
@@ -65,8 +66,14 @@ def test_app_watch(tmp_path):
     testfile = tmp_path / "test0"
     testfile.touch()
 
+    # check the threating is working
+    assert threading.active_count() > 1
+
     app_watch.stop()
-    app_watch.join()
+    app_watch.join(timeout=5.0)
+
+    # check the threating is stopped and joined
+    assert threading.active_count() == 1
 
     assert app_watch.is_alive() is False
     assert app_watch._observer.is_alive() is False

--- a/tests/test_appclass.py
+++ b/tests/test_appclass.py
@@ -1,9 +1,13 @@
+from dataclasses import dataclass
+from pathlib import Path
+from time import sleep
+
 import aiida
 import pytest
 import traitlets
 from packaging import version
 
-from aiidalab.app import AiidaLabApp
+from aiidalab.app import AiidaLabApp, AiidaLabAppWatch
 
 
 def test_init_refresh(generate_app):
@@ -39,13 +43,6 @@ def test_dependencies(generate_app):
     with pytest.raises(traitlets.TraitError):
         app.version_to_install = "v22.11.0"
     app.version_to_install = "v22.11.1"
-
-
-from dataclasses import dataclass
-from pathlib import Path
-from time import sleep
-
-from aiidalab.app import AiidaLabAppWatch
 
 
 def test_app_watch(tmp_path):

--- a/tests/test_appclass.py
+++ b/tests/test_appclass.py
@@ -71,7 +71,7 @@ def test_app_watch(tmp_path):
     # The observer is start in a thread so need to wait until it is alive
     while app_watch._observer is None or not app_watch._observer.is_alive():
         sleep(0.1)
-    
+
     # Trigger action by file events
     # touch a file will trigger action 4 times: create and close file and two modifies of folder
     testfile = tmp_path / "test0"
@@ -79,11 +79,11 @@ def test_app_watch(tmp_path):
 
     app_watch.stop()
     app_watch.join()
-    
+
     assert app.x == 4
-    
+
     # After the thread is stop and join the obsever is inactivate and will not trigger refresh_async
     testfile = tmp_path / "test1"
     testfile.touch()
-    
+
     assert app.x == 4

--- a/tests/test_appclass.py
+++ b/tests/test_appclass.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from time import sleep
 
-import aiida
 import pytest
 import traitlets
 
@@ -49,14 +48,12 @@ def test_app_watch(tmp_path):
     class DummyApp:
         path: Path
         x: int = 0
-        y: int = 0
 
         def refresh_async(self):
             self.x += 1
 
         def refresh(self):
-            print("refresh")
-            self.y += 1
+            pass
 
     app = DummyApp(path=Path(tmp_path))
     app_watch = AiidaLabAppWatch(app)
@@ -76,7 +73,8 @@ def test_app_watch(tmp_path):
 
     assert app.x == 4
 
-    # After the thread is stop and join the obsever is inactivate and will not trigger refresh_async
+    # The stop of watch monitor thread will trigger stop of observer's thread. 
+    # After the observer is stopped, file system events should no longer trigger `refresh_async`
     testfile = tmp_path / "test1"
     testfile.touch()
 


### PR DESCRIPTION
fixes #361 

I did the minimal change by replace `_stop_flag` with the `threading.Event` object. 