### PR TITLE
available versions list unified by consider prereleases and core compatible in same function

### DIFF
--- a/aiidalab/__main__.py
+++ b/aiidalab/__main__.py
@@ -288,7 +288,7 @@ def _find_version_to_install(
                     f"Unable to check compatibility for {app_requirement} prior to installation."
                 )
 
-        if force or not app.is_installed():
+        if force or not app.is_installed:
             return app, PEP508CompliantUrl(app_requirement.url)
         else:
             return app, None

--- a/aiidalab/__main__.py
+++ b/aiidalab/__main__.py
@@ -288,7 +288,7 @@ def _find_version_to_install(
                     f"Unable to check compatibility for {app_requirement} prior to installation."
                 )
 
-        if force or not app.is_installed:
+        if force or not app.is_installed():
             return app, PEP508CompliantUrl(app_requirement.url)
         else:
             return app, None

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -728,7 +728,7 @@ class AiidaLabApp(traitlets.HasTraits):  # type: ignore
         except KeyError:
             raise ValueError(f"Did not find categories in {self.name} metadata")
 
-        self.is_installed = self._app.is_installed()
+        self.is_installed = self._app.is_installed
         self.path = str(self._app.path)
         self.refresh_async()
 

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -218,7 +218,7 @@ class _AiidaLabApp:
                 return AppRemoteUpdateStatus.DETACHED
 
             # Check whether the locally installed version is the latest release.
-            available_versions = self.available_versions(prereleases=prereleases)
+            available_versions = list(self.available_versions(prereleases=prereleases))
             if len(available_versions) and installed_version != available_versions[0]:
                 return AppRemoteUpdateStatus.UPDATE_AVAILABLE
 

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -755,7 +755,9 @@ class AiidaLabApp(traitlets.HasTraits):  # type: ignore
     def _default_detached(self):
         """Provide default value for detached traitlet."""
         if self.is_installed():
-            return self._app.dirty() or self._installed_version() is AppVersion.UNKNOWN
+            return (
+                self._app.dirty() or self._get_installed_version() is AppVersion.UNKNOWN
+            )
         return None
 
     @traitlets.default("busy")
@@ -818,7 +820,7 @@ class AiidaLabApp(traitlets.HasTraits):  # type: ignore
             )
             FIND_INSTALLED_PACKAGES_CACHE.clear()
             self.refresh()
-            return self._installed_version()
+            return self._get_installed_version()
 
     def update_app(self, _=None, stdout=None) -> AppVersion | str:
         """Perform app update."""
@@ -837,9 +839,9 @@ class AiidaLabApp(traitlets.HasTraits):  # type: ignore
             self._app.uninstall()
             self.refresh()
 
-    def _installed_version(self) -> AppVersion | str:
+    def _get_installed_version(self) -> AppVersion | str:
         """Determine the currently installed version."""
-        return self._app.installed_version()  # type: ignore
+        return self._app.installed_version()
 
     @traitlets.default("compatible")  # type: ignore
     def _default_compatible(self) -> None:  # pylint: disable=no-self-use
@@ -863,7 +865,9 @@ class AiidaLabApp(traitlets.HasTraits):  # type: ignore
             return False  # compatibility indetermined for given version
 
     def _refresh_versions(self) -> None:
-        self.installed_version = self._installed_version()
+        self.installed_version = (
+            self._get_installed_version()
+        )  # only update at this refresh method
         self.include_prereleases = self.include_prereleases or (
             isinstance(self.installed_version, str)
             and parse(self.installed_version).is_prerelease

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -832,7 +832,7 @@ class AiidaLabApp(traitlets.HasTraits):  # type: ignore
             self.refresh()
             return version
 
-    def uninstall_app(self, _=None):  # type: ignore
+    def uninstall_app(self, _=None):
         """Perfrom app uninstall."""
         # Perform uninstall process.
         with self._show_busy():
@@ -916,7 +916,7 @@ class AiidaLabApp(traitlets.HasTraits):  # type: ignore
         refresh_thread.start()
 
     @property
-    def metadata(self):  # type: ignore
+    def metadata(self):
         """Return metadata dictionary. Give the priority to the local copy (better for the developers)."""
         return self._app.metadata
 

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -162,8 +162,9 @@ class _AiidaLabApp:
                         f"Encountered error while determining version: {error}"
                     )
                     return AppVersion.UNKNOWN
-        elif self.path.exists():
+        elif self.is_installed():
             return self.metadata.get("version", AppVersion.UNKNOWN)
+
         return AppVersion.NOT_INSTALLED
 
     def available_versions(
@@ -727,7 +728,7 @@ class AiidaLabApp(traitlets.HasTraits):  # type: ignore
         except KeyError:
             raise ValueError(f"Did not find categories in {self.name} metadata")
 
-        self.is_installed = self._app.is_installed
+        self.is_installed = self._app.is_installed()
         self.path = str(self._app.path)
         self.refresh_async()
 

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -828,19 +828,6 @@ class AiidaLabApp(traitlets.HasTraits):  # type: ignore
         except KeyError:
             return False  # compatibility indetermined for given version
 
-    def _remote_update_status(self) -> bool:
-        """Determine whether there are updates available.
-
-        For this the app must be installed in a known version and there must be
-        available (and compatible) versions.
-        """
-        installed_version = self._installed_version()
-        if installed_version not in (AppVersion.UNKNOWN, AppVersion.NOT_INSTALLED):
-            available_versions = list(self.available_versions)
-            if len(available_versions):
-                return self._installed_version() != available_versions[0]  # type: ignore
-        return False
-
     def _refresh_versions(self) -> None:
         self.installed_version = self._installed_version()
         self.include_prereleases = self.include_prereleases or (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,16 +3,16 @@ from pathlib import Path
 import pytest
 import yaml
 
-from aiidalab.app import AiidaLabApp
+from aiidalab.app import AiidaLabApp, _AiidaLabApp
 
 
 @pytest.fixture
-def generate_app():
+def generate_app(monkeypatch):
     """Fixture to construct a new AiiDALabApp instance for testing."""
 
     def _generate_app(
         name="quantum-espresso",
-        aiidalab_apps_path="/home/jovyan/apps",
+        aiidalab_apps_path="/tmp/apps",
         app_data=None,
         watch=False,
     ):
@@ -21,6 +21,11 @@ def generate_app():
                 Path(__file__).parent.absolute() / "static/app_registry.yaml"
             ) as f:
                 app_data = yaml.safe_load(f)
+
+        # In the app_registry.yaml we defined the metadata which means
+        # it is a installed app. Following monkeypatch make it more close
+        # to the real scenario for test.
+        monkeypatch.setattr(_AiidaLabApp, "is_installed", lambda _: True)
         app = AiidaLabApp(name, app_data, aiidalab_apps_path, watch=watch)
 
         return app

--- a/tests/test_appclass.py
+++ b/tests/test_appclass.py
@@ -6,7 +6,7 @@ from time import sleep
 import pytest
 import traitlets
 
-from aiidalab.app import AiidaLabApp, AiidaLabAppWatch
+from aiidalab.app import AiidaLabApp, AiidaLabAppWatch, _AiidaLabApp
 
 
 def test_init_refresh(generate_app):
@@ -40,6 +40,23 @@ def test_dependencies(generate_app):
     with pytest.raises(traitlets.TraitError):
         app.version_to_install = "v22.11.0"
     app.version_to_install = "v22.11.1"
+
+
+@pytest.mark.usefixtures("installed_packages")
+def test_app_is_not_registered(generate_app, monkeypatch):
+    """test the app is not registered and the available versions are empty."""
+    app: AiidaLabApp = generate_app()
+
+    # monkeypatch and make the app not registered
+    monkeypatch.setattr(_AiidaLabApp, "is_registered", False)
+    app.refresh()
+
+    assert app._app.is_registered is False
+
+    # if the app is not registered, the version is read from the metadata of app installed
+    # the available versions will be empty since the app is not registered
+    assert app.installed_version == "23.1.0"
+    assert len(app.available_versions) == 0
 
 
 def test_app_watch(tmp_path):

--- a/tests/test_appclass.py
+++ b/tests/test_appclass.py
@@ -47,13 +47,11 @@ def test_app_is_not_registered(generate_app, monkeypatch, tmp_path):
     """test the app is not registered and the available versions are empty."""
     # monkeypatch and make the app not registered
     monkeypatch.setattr(_AiidaLabApp, "is_registered", False)
-    monkeypatch.setattr(_AiidaLabApp, "is_installed", lambda _: True)
 
     app: AiidaLabApp = generate_app()
     app.refresh()
 
-    assert app._app.is_registered is False
-    assert app.is_installed is True
+    assert app.is_installed() is True
 
     # if the app is not registered, the version is read from the metadata of app installed
     # the available versions will be empty since the app is not registered

--- a/tests/test_appclass.py
+++ b/tests/test_appclass.py
@@ -43,15 +43,17 @@ def test_dependencies(generate_app):
 
 
 @pytest.mark.usefixtures("installed_packages")
-def test_app_is_not_registered(generate_app, monkeypatch):
+def test_app_is_not_registered(generate_app, monkeypatch, tmp_path):
     """test the app is not registered and the available versions are empty."""
-    app: AiidaLabApp = generate_app()
-
     # monkeypatch and make the app not registered
     monkeypatch.setattr(_AiidaLabApp, "is_registered", False)
+    monkeypatch.setattr(_AiidaLabApp, "is_installed", lambda _: True)
+
+    app: AiidaLabApp = generate_app()
     app.refresh()
 
     assert app._app.is_registered is False
+    assert app.is_installed is True
 
     # if the app is not registered, the version is read from the metadata of app installed
     # the available versions will be empty since the app is not registered

--- a/tests/test_appdataclass.py
+++ b/tests/test_appdataclass.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 from packaging.requirements import Requirement
 
-from aiidalab.app import _AiidaLabApp, AppRemoteUpdateStatus
+from aiidalab.app import AppRemoteUpdateStatus, _AiidaLabApp
 
 _MONKEYPATCHED_INSTALLED_PACKAGES = [
     {"name": "aiida-core", "version": "2.2.1"},
@@ -105,6 +105,7 @@ def test_find_dependencies_to_install(monkeypatch, installed_packages, python_bi
     assert "aiida-core" not in dependencies_name
     assert "jupyter-client" in dependencies_name
 
+
 def test_update_status_issue_360(monkeypatch, installed_packages, python_bin):
     """Test issue #360 where when the highest version is core dependencies unmet and hidden."""
     monkeypatch.setattr(_AiidaLabApp, "is_registered", True)
@@ -125,10 +126,10 @@ def test_update_status_issue_360(monkeypatch, installed_packages, python_bin):
                 "metadata": {},
                 "url": "",
             },
-            "v0.1.0": { # installed version where the aiida-core compatible
+            "v0.1.0": {  # installed version where the aiida-core compatible
                 "environment": {
                     "python_requirements": [
-                        "aiida-core~=2.0", 
+                        "aiida-core~=2.0",
                     ],
                 },
                 "metadata": {},
@@ -136,5 +137,5 @@ def test_update_status_issue_360(monkeypatch, installed_packages, python_bin):
             },
         },
     )
-    
+
     assert aiidalab_app_data.remote_update_status() is AppRemoteUpdateStatus.UP_TO_DATE

--- a/tests/test_appdataclass.py
+++ b/tests/test_appdataclass.py
@@ -94,7 +94,8 @@ def test_update_status_of_unregistred_app(
     # The app is installed in the path but the app name is not found from the registry.
     # This leads to the app being unregistred and the version will be read from the metadata.
     # If the version is not found in the metadata, the app is considered as `AppVersion.UNKNOWN`
-    # The path need to be exist otherwise the app considered to be not installed.
+    # The path need to be exist otherwise the app considered to be not installed, in the test
+    # we monkeypatch in as installed.
     monkeypatch.setattr(_AiidaLabApp, "is_installed", lambda _: True)
     monkeypatch.setattr(_AiidaLabApp, "is_registered", False)
 

--- a/tests/test_appdataclass.py
+++ b/tests/test_appdataclass.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 from packaging.requirements import Requirement
 
-from aiidalab.app import AppRemoteUpdateStatus, _AiidaLabApp
+from aiidalab.app import AppRemoteUpdateStatus, AppVersion, _AiidaLabApp
 
 
 @pytest.fixture
@@ -87,7 +87,33 @@ def test_find_dependencies_to_install(monkeypatch, installed_packages, python_bi
     assert "jupyter-client" in dependencies_name
 
 
-def test_update_status_issue_360(monkeypatch, installed_packages, python_bin):
+def test_update_status_of_unregistred_app(
+    monkeypatch, installed_packages, python_bin, tmp_path
+):
+    """Test default behaviour of an unregistred app."""
+    # The app is installed in the path but the app name is not found from the registry.
+    # This leads to the app being unregistred and the version will be read from the metadata.
+    # If the version is not found in the metadata, the app is considered as `AppVersion.UNKNOWN`
+    # The path need to be exist otherwise the app considered to be not installed.
+    monkeypatch.setattr(_AiidaLabApp, "is_installed", lambda _: True)
+    monkeypatch.setattr(_AiidaLabApp, "is_registered", False)
+
+    aiidalab_app_data = _AiidaLabApp(
+        metadata={},
+        name="test",
+        path=tmp_path,
+        releases={},
+    )
+
+    assert (
+        aiidalab_app_data.remote_update_status() is AppRemoteUpdateStatus.NOT_REGISTERED
+    )
+    assert aiidalab_app_data.installed_version() is AppVersion.UNKNOWN
+
+
+def test_update_status_latest_version_incompatible(
+    monkeypatch, installed_packages, python_bin
+):
     """Test issue #360 where when the highest version is core dependencies unmet and hidden."""
     monkeypatch.setattr(_AiidaLabApp, "is_registered", True)
     monkeypatch.setattr(_AiidaLabApp, "is_installed", lambda _: True)


### PR DESCRIPTION
fixes #360 

The `available_versions` of _AiidalabApp data class object not considered core compatible. The core compatible check is implement independently and sporadically when the `available_versions` list is required.  
This commit add the core compatible check inside the function `available_versions` of _AiidalabApp class to get the only usable versions for both when prereleases option is on and off. Therefore the version list conforms with what is shown in the version_to_install dropdown option.