### PR TITLE
CLI: Add -h option as an alias for --help

### DIFF
--- a/aiidalab/__main__.py
+++ b/aiidalab/__main__.py
@@ -68,7 +68,7 @@ def _list_apps(apps_path):
         )
 
 
-@click.group()
+@click.group(context_settings={"help_option_names": ["-h", "--help"]})
 @click.version_option(version=__version__, prog_name="AiiDAlab")
 @click.option("-v", "--verbose", count=True)
 def cli(verbose):

--- a/aiidalab/config.py
+++ b/aiidalab/config.py
@@ -1,4 +1,4 @@
-"""Module to manange AiiDAlab configuration."""
+"""Module to manage AiiDAlab configuration."""
 from os import getenv
 from pathlib import Path
 

--- a/tests/test_appclass.py
+++ b/tests/test_appclass.py
@@ -7,7 +7,7 @@ from aiidalab.app import AiidaLabApp
 def test_init_refresh(generate_app):
     app = generate_app()
     assert len(app.available_versions) == 0
-    # After refresh the availale_versions traitlets is updated
+    # After refresh the available_versions traitlet is updated
     app.refresh()
     assert len(app.available_versions) != 0
 


### PR DESCRIPTION
Based on user feedback at the last AiiDA hackathon,
`verdi` command now supports `-h` option as an alias for `--help`, as of https://github.com/aiidateam/aiida-core/pull/5792

Let's do the same thing here.

If you agree with this, I'll submit the same PR for `aiidalab-launch` as well.