### PR TITLE
Catch all exceptions when installing app

### DIFF
--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -356,7 +356,7 @@ class _AiidaLabApp:
             # https://www.endpoint.com/blog/2015/01/getting-realtime-output-using-python/
 
             # Install package dependencies.
-            stdout.write(f"Running 'pip install --user {' '.join(args)}'\n")
+            logger.info(f"Running 'pip install --user {' '.join(args)}'\n")
             process = run_pip_install(*args, python_bin=python_bin)
             for line in io.TextIOWrapper(process.stdout, encoding="utf-8"):
                 stdout.write(line)
@@ -366,7 +366,7 @@ class _AiidaLabApp:
 
             # AiiDA plugins require reentry run to be found by AiiDA.
             if _should_run_reentry():
-                stdout.write("\nRunning 'reentry scan'\n")
+                logger.info("\nRunning 'reentry scan'\n")
                 process = run_reentry_scan()
                 for line in io.TextIOWrapper(process.stdout, encoding="utf-8"):
                     stdout.write(line)
@@ -417,6 +417,9 @@ class _AiidaLabApp:
             process = run_post_install_script(post_install_file)
             process.wait()
             if process.returncode != 0:
+                logger.error(
+                    f'Post-install script "{post_install_file}" returned an error!'
+                )
                 raise CalledProcessError(process.returncode, str(post_install_file))
 
     def _install_from_path(self, path):
@@ -522,18 +525,22 @@ class _AiidaLabApp:
             if post_install_triggers:
                 self._post_install_triggers()
 
-        except RuntimeError as error:
+        # NOTE: We want to catch everything, including keyboard interrupt,
+        # so we can rollback incomplete installation.
+        except BaseException as error:
             try:
                 if trash_path is None:
                     # App, was not previously installed, just remove it.
-                    logger.info("Removing partially installed app.")
+                    logger.warning("Removing partially installed app.")
                     self._move_to_trash()
                 else:
                     # Attempt rollback to previous version.
-                    logger.info("Performing rollback to previously installed version.")
+                    logger.warning(
+                        "Performing rollback to previously installed version."
+                    )
                     self._restore_from(trash_path)
             except RuntimeError as inner_error:
-                logger.warning(f"Rollback failed due to error: {inner_error}!")
+                logger.error(f"Rollback failed due to error: {inner_error}!")
             finally:
                 raise RuntimeError(
                     f"Failed to install '{self.name}' (version={version}) at '{self.path}'"


### PR DESCRIPTION
### Summary

Previously, we were only catching RuntimeError which left a lot of room for other failures during installation, which would result in an incomplete installation of an app. Generally, there's no way of knowing after-the-fact that the installation ended prematurely, e.g. `aiidalab list` would show the app as installed.

Note that this includes for example `post_install` script failures.

Now we catch everything, including Keyboard interrupts, so that we always trigger the already existing rollback mechanism.

See issue #334 for details of how to reproduce this.

### Test plan

1. Trigger installation of an app from CLI `aiidalab -v install aurora==0.2.1`
2. Interrupt the installation in the middle with Ctrl+C
3. The installation should rollback. Verify with `aiidalab list` that the app is not installed.
4. Try installing an app from a following URL, where I specifically modified the `post_install` script to fail. `aiidalab -v install aiidalab-ispg@git+https://github.com/ispg-group/aiidalab-ispg@post-install-fail`
5. Failing post_install should now trigger rollback as well.

Closes #334

Note that the more robust fix to this should be done in #364 