### PR TITLE
Add name of Package as the property

### DIFF
--- a/aiidalab/utils.py
+++ b/aiidalab/utils.py
@@ -165,6 +165,11 @@ class Package:
         return f"{self.canonical_name}=={self.version}"
 
     @property
+    def name(self) -> str:
+        """Return the name (not necessary canonicalized) of the package."""
+        return self._name
+
+    @property
     def canonical_name(self) -> NormalizedName:
         """Return the cananicalized name of the package."""
         return canonicalize_name(self._name)


### PR DESCRIPTION
This change is required by https://github.com/aiidalab/aiidalab-widgets-base/pull/446. Since we change the Package.name to `_name` in https://github.com/aiidalab/aiidalab/pull/347.