### PR TITLE
incompatibility check for app detached will go through the local repo

### DIFF
--- a/aiidalab/__main__.py
+++ b/aiidalab/__main__.py
@@ -198,7 +198,7 @@ def _find_registered_app_from_id(name):
     """Find app for a given requirement."""
     try:
         app = AiidaLabApp.from_id(name)
-        if app.is_registered:
+        if app.is_registered():
             return app
         else:
             raise click.ClickException(

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -287,11 +287,12 @@ class _AiidaLabApp:
         return self.remote_update_status() == AppRemoteUpdateStatus.DETACHED
 
     def find_incompatibilities(self, version, python_bin=None):
-        """Compatibility is checked by comparing between the requirement list of package
+        """Compatibility is checked by comparing the app requirements
         with the packages installed in the python environment.
-        If the app is registried which means the requirments list can get for certain version only,
-        it will checked w.r.t that. If the app is not registried or it is detached which usually caused from
-        the app is modified locally the requirements list will directly read from the local repository.
+
+        If the app is registered the list of requirements is fetched from the registry for the specific version.
+        If the app is not registered or if it is detached (i.e. locally modified),
+        the requirements list is read from the local repository (e.g. by parsing setup.cfg).
         """
         if python_bin is None:
             python_bin = sys.executable
@@ -863,11 +864,7 @@ class AiidaLabApp(traitlets.HasTraits):  # type: ignore
         return None
 
     def _is_compatible(self, app_version: str) -> bool:
-        """Determine whether the specified version is compatible.
-
-        Note: if the app_version is UNKNOWN, then the compatibility is indetermined and False is returned.
-        This usually happens when the app is detached.
-        """
+        """Determine whether the specified version is compatible."""
         try:
             incompatibilities = dict(
                 self._app.find_incompatibilities(version=app_version)

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -283,12 +283,21 @@ class _AiidaLabApp:
             elif not pkg.fulfills(requirement):
                 yield requirement
 
+    def is_detached(self):
+        """Check whether the app is detached from the registry."""
+        return self.remote_update_status() == AppRemoteUpdateStatus.DETACHED
+
     def find_incompatibilities(self, version, python_bin=None):
+        """Compatibility is checked by comparing between the requirement list of package
+        with the packages installed in the python environment.
+        If the app is registried which means the requirments list can get for certain version only,
+        it will checked w.r.t that. If the app is not registried or it is detached which usually caused from
+        the app is modified locally the requirements list will directly read from the local repository.
+        """
         if python_bin is None:
             python_bin = sys.executable
 
-        if not self.is_registered:
-            assert version == self.installed_version()
+        if not self.is_registered or self.is_detached():
             environment = asdict(Environment.scan(self.path))
         else:
             environment = self.releases[version].get("environment", {})

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -125,7 +125,6 @@ class _AiidaLabApp:
 
         return cls.from_registry_entry(path=app_path, registry_entry=registry_entry)
 
-    @property
     def is_registered(self):
         try:
             app_registry_index = load_app_registry_index()
@@ -143,7 +142,7 @@ class _AiidaLabApp:
             return None
 
     def installed_version(self) -> AppVersion | str:
-        if self._repo and self.is_registered:
+        if self._repo and self.is_registered():
             if self.dirty():
                 return AppVersion.UNKNOWN
             else:
@@ -173,7 +172,7 @@ class _AiidaLabApp:
         prereleases: bool = False,
     ) -> Generator[str, None, None]:
         """Return a list of available versions excluding the ones with core dependency conflicts."""
-        if self.is_registered:
+        if self.is_registered():
             for version in sorted(self.releases, key=parse, reverse=True):
                 version_requirements = [
                     Requirement(r)
@@ -208,10 +207,10 @@ class _AiidaLabApp:
         if self.is_installed():
 
             # Check whether app is registered.
-            if self.is_registered is None:
+            if self.is_registered() is None:
                 return AppRemoteUpdateStatus.CANNOT_REACH_REGISTRY
 
-            if self.is_registered is False:
+            if self.is_registered() is False:
                 return AppRemoteUpdateStatus.NOT_REGISTERED
 
             # Check whether the locally installed version is a registered release.
@@ -297,7 +296,7 @@ class _AiidaLabApp:
         if python_bin is None:
             python_bin = sys.executable
 
-        if not self.is_registered or self.is_detached():
+        if not self.is_registered() or self.is_detached():
             environment = asdict(Environment.scan(self.path))
         else:
             environment = self.releases[version].get("environment", {})
@@ -926,7 +925,7 @@ class AiidaLabApp(traitlets.HasTraits):  # type: ignore
                 self.set_trait(
                     "detached",
                     (self.installed_version is AppVersion.UNKNOWN)
-                    if (self._has_git_repo() and self._app.is_registered)
+                    if (self._has_git_repo() and self._app.is_registered())
                     else None,
                 )
 

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -855,7 +855,11 @@ class AiidaLabApp(traitlets.HasTraits):  # type: ignore
         return None
 
     def _is_compatible(self, app_version: str) -> bool:
-        """Determine whether the specified version is compatible."""
+        """Determine whether the specified version is compatible.
+
+        Note: if the app_version is UNKNOWN, then the compatibility is indetermined and False is returned.
+        This usually happens when the app is detached.
+        """
         try:
             incompatibilities = dict(
                 self._app.find_incompatibilities(version=app_version)

--- a/tests/test_appclass.py
+++ b/tests/test_appclass.py
@@ -46,7 +46,7 @@ def test_dependencies(generate_app):
 def test_app_is_not_registered(generate_app, monkeypatch, tmp_path):
     """test the app is not registered and the available versions are empty."""
     # monkeypatch and make the app not registered
-    monkeypatch.setattr(_AiidaLabApp, "is_registered", False)
+    monkeypatch.setattr(_AiidaLabApp, "is_registered", lambda _: False)
 
     app: AiidaLabApp = generate_app()
     app.refresh()

--- a/tests/test_appdataclass.py
+++ b/tests/test_appdataclass.py
@@ -147,3 +147,43 @@ def test_update_status_latest_version_incompatible(
     )
 
     assert aiidalab_app_data.remote_update_status() is AppRemoteUpdateStatus.UP_TO_DATE
+
+
+def test_compatibility_check_with_local_repo_if_detached(
+    monkeypatch, tmp_path, installed_packages
+):
+    """Test compatibility check with local repo if detached."""
+    from aiidalab.environment import Environment
+
+    monkeypatch.setattr(_AiidaLabApp, "is_installed", lambda _: True)
+    monkeypatch.setattr(_AiidaLabApp, "is_registered", True)
+
+    aiidalab_app_data = _AiidaLabApp(
+        metadata={},
+        name="test",
+        path=tmp_path,
+        releases={},
+    )
+
+    assert aiidalab_app_data.installed_version() is AppVersion.UNKNOWN
+    assert aiidalab_app_data.is_detached()
+
+    # test to show the code path that the local repo requirements check is hinted.
+    # because the Environment.scan method is used for check the compatibility of local repo.
+
+    # monkeypatch the scan method to return a fake environment
+    # the fake environment has the aiida-core version that is compatible with the app
+    monkeypatch.setattr(
+        Environment,
+        "scan",
+        lambda _: Environment(python_requirements=["aiida-core~=2.0"]),
+    )
+    assert len(list(aiidalab_app_data.find_incompatibilities("v0.1.0"))) == 0
+
+    # the fake environment has the aiida-core version that is not compatible with the app
+    monkeypatch.setattr(
+        Environment,
+        "scan",
+        lambda _: Environment(python_requirements=["aiida-core~=3.0"]),
+    )
+    assert len(list(aiidalab_app_data.find_incompatibilities("v0.1.0"))) == 1

--- a/tests/test_appdataclass.py
+++ b/tests/test_appdataclass.py
@@ -50,7 +50,7 @@ def test_strict_dependencies_met_package_name_canonicalized(
 def test_find_dependencies_to_install(monkeypatch, installed_packages, python_bin):
     """Test find_dependencies_to_install method of _AiidaLabApp.
     By mocking the _AiidallabApp class with its attributes set."""
-    monkeypatch.setattr(_AiidaLabApp, "is_registered", True)
+    monkeypatch.setattr(_AiidaLabApp, "is_registered", lambda _: True)
 
     aiidalab_app_data = _AiidaLabApp(
         metadata={},
@@ -97,7 +97,7 @@ def test_update_status_of_unregistred_app(
     # The path need to be exist otherwise the app considered to be not installed, in the test
     # we monkeypatch in as installed.
     monkeypatch.setattr(_AiidaLabApp, "is_installed", lambda _: True)
-    monkeypatch.setattr(_AiidaLabApp, "is_registered", False)
+    monkeypatch.setattr(_AiidaLabApp, "is_registered", lambda _: False)
 
     aiidalab_app_data = _AiidaLabApp(
         metadata={},
@@ -116,7 +116,7 @@ def test_update_status_latest_version_incompatible(
     monkeypatch, installed_packages, python_bin
 ):
     """Test issue #360 where when the highest version is core dependencies unmet and hidden."""
-    monkeypatch.setattr(_AiidaLabApp, "is_registered", True)
+    monkeypatch.setattr(_AiidaLabApp, "is_registered", lambda _: True)
     monkeypatch.setattr(_AiidaLabApp, "is_installed", lambda _: True)
     monkeypatch.setattr(_AiidaLabApp, "installed_version", lambda _: "v0.1.0")
 
@@ -156,7 +156,7 @@ def test_compatibility_check_with_local_repo_if_detached(
     from aiidalab.environment import Environment
 
     monkeypatch.setattr(_AiidaLabApp, "is_installed", lambda _: True)
-    monkeypatch.setattr(_AiidaLabApp, "is_registered", True)
+    monkeypatch.setattr(_AiidaLabApp, "is_registered", lambda _: True)
 
     aiidalab_app_data = _AiidaLabApp(
         metadata={},


### PR DESCRIPTION
fixes #373 

When the app is installed but the app repo gets new commit, the app version will become UNKNOWN. Therefore, the requirements list cannot check with the version from the registered list. Rather the requirements list needs to access from the local repo. 
Check requirements upon local repo happened for the app not registered but also should be for the app detached. The condition is added for detached app for incompatibility check.