### PR TITLE
Officially drop support for Python 3.7, test 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
             - name: Set up Python 3.9
               uses: actions/setup-python@v2
               with:
-                  python-version: 3.9
+                  python-version: '3.10'
             - uses: pre-commit/action@v2.0.0
 
     test-package:
@@ -24,7 +24,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: ['3.8', '3.9', '3.10']
+                python-version: ['3.8', '3.9', '3.10', '3.11']
 
         steps:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
     traitlets~=5.0
     urllib3~=1.24
     watchdog~=2.3
-python_requires = >=3.7
+python_requires = >=3.8
 include_package_data = True
 zip_safe = False
 


### PR DESCRIPTION
We've stopped testing Python 3.7 a while ago, and "dropped" the support in #305, but forgot to actually update `setup.cfg`.

Here's a list of new features in Python 3.8, most notably the walrus operator and the `f"{var=}"` debug syntax for  f-strings. I've verified with grep that we've not used these features yet.

https://docs.python.org/3/whatsnew/3.8.html#summary-release-highlights