### PR TITLE
Fix base.html URLs

### DIFF
--- a/aiidalab/registry/templates/base.html
+++ b/aiidalab/registry/templates/base.html
@@ -1,7 +1,7 @@
 <!doctype html>
 
-{% set app_registry_url = "http://aiidateam.github.io/aiida-registry" %}
-{% set aiidalab_url = "https://www.materialscloud.org/aiidalab" %}
+{% set app_registry_url = "https://aiidalab.github.io/aiidalab-registry/" %}
+{% set aiidalab_url = "https://www.aiidalab.net/" %}
 
 <html lang="en">
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -88,7 +88,7 @@ html_theme = "pydata_sphinx_theme"
 
 html_theme_options = {
     "external_links": [
-        {"url": "https://www.materialscloud.org/aiidalab", "name": "AiiDAlab"}
+        {"url": "https://www.aiidalab.net/", "name": "AiiDAlab"}
     ],
     "github_url": "https://github.com/aiidalab/aiidalab",
     "use_edit_page_button": True,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -87,9 +87,7 @@ exclude_patterns = []
 html_theme = "pydata_sphinx_theme"
 
 html_theme_options = {
-    "external_links": [
-        {"url": "https://www.aiidalab.net/", "name": "AiiDAlab"}
-    ],
+    "external_links": [{"url": "https://www.aiidalab.net/", "name": "AiiDAlab"}],
     "github_url": "https://github.com/aiidalab/aiidalab",
     "use_edit_page_button": True,
 }

--- a/docs/source/usage/index.rst
+++ b/docs/source/usage/index.rst
@@ -9,7 +9,7 @@ Access AiiDAlab
 
 As a user, you have three options to access AiiDAlab:
 
- 1. Log into one of the `open AiiDAlab servers <https://materialscloud.org/aiidalab>`_.
+ 1. Log into one of the `open AiiDAlab servers <https://www.aiidalab.net/deployments/>`_.
  2. Run the AiiDAlab docker container directly :ref:`on your local machine <usage:run-locally>`.
  3. Download the `Quantum Mobile Virtual Machine <https://quantum-mobile.readthedocs.io/>`_, open a terminal and run ``aiidalab``.
 


### PR DESCRIPTION
Solves #371 
Updated the URLs used in the footer of the application to use the correct links. Previously, the links were pointing to the wrong resources, but have been updated to point to the correct URLs. This includes updating the links to the AiiDAlab registry page in the aiidalab-registry repository. These changes ensure that users can access the correct resources from the footer of the application.


This pull request fixes an issue in the parent file `base.html` at https://github.com/aiidalab/aiidalab/blob/50498b08ea77937cb8af0e8d753446dd17b6d637/aiidalab/registry/templates/base.html#L3 which was causing issues in the child file `layout.html` at https://github.com/aiidalab/aiidalab-registry/blob/8bc5d00fffa2016f562d065d81bd5a111c99479e/src/templates/layout.html#L8. The issue was causing variables to not be overwritten in the registry repository. The changes made in this pull request fix the links in the footer, and ensure that the variables can be correctly overwritten in the child file.
