### PR TITLE
Allow for removing setup.py in favour of simple pyproject.toml

### DIFF
--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -395,7 +395,10 @@ class _AiidaLabApp:
         for path in (self.path.joinpath(".aiidalab"), self.path):
             if path.exists():
                 try:
-                    if path.joinpath("setup.py").is_file():
+                    if (
+                        path.joinpath("setup.py").is_file()
+                        or path.joinpath("pyproject.toml").is_file()
+                    ):
                         _pip_install(str(path), stdout=stdout)
                     elif path.joinpath("requirements.txt").is_file():
                         _pip_install(


### PR DESCRIPTION
Step toward #342.

In this PR, we still require the `setup.cfg`, but instead of dummy `setup.py`, we can now user a rudimentary `pyproject.toml` to declare the build dependencies explicitly.