### PR TITLE
support using _ for matching all branches in getting registry

### DIFF
--- a/docs/source/app_development/publish.rst
+++ b/docs/source/app_development/publish.rst
@@ -98,13 +98,16 @@ Here we explain how an app can be made available to AiiDAlab users by registerin
 
    .. tabbed:: Release all tagged commits
 
-       The simplest approach to release new app versions, is to register the app *once* and then push new releases by creating tagged commits on a specific branch, e.g., the *main* branch.
+       The simplest approach to release new app versions, is to register the app *once* and then push new releases by creating tagged commits on a specific branch, e.g., the *main* branch, or *`_`* to get tags from all branches.
 
        .. code-block:: yaml
 
-           my-app:
+           my-app1:
              releases:
                - "git+https://github.com/aiidalab/aiidalab-my-app@main:"
+           my-app2:
+             releases:
+               - "git+https://github.com/aiidalab/aiidalab-my-app@_:v1.0.0.."
 
        where you replace the URL shown here with the one applicable for your app.
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,32 @@
+import os
+from urllib.parse import urlsplit
+
+from aiidalab.registry.releases import _get_release_commits, _split_release_line
+from aiidalab.fetch import fetch_from_url, GitRepo
+
+def test_get_all_tagged_releases():
+    """Test that all tagged releases are returned."""
+    url = "git+https://github.com/aiidalab/aiidalab-qe.git@_:v23.04.0^.."
+    base_url, release_line = _split_release_line(url)
+    parsed_url = urlsplit(base_url)
+    
+    with fetch_from_url(base_url) as repo_path:
+        if parsed_url.scheme.startswith("git+"):
+            repo = GitRepo(os.fspath(repo_path))
+            releases = [tag for tag, _ in _get_release_commits(repo, release_line)]
+            
+    assert "v23.04.2" in releases
+    
+def test_get_releases_from_branch():
+    """Test that all tagged releases of perticular branch (main) are returned."""
+    url = "git+https://github.com/aiidalab/aiidalab-qe.git@main:v23.04.0^.."
+    base_url, release_line = _split_release_line(url)
+    parsed_url = urlsplit(base_url)
+    
+    with fetch_from_url(base_url) as repo_path:
+        if parsed_url.scheme.startswith("git+"):
+            repo = GitRepo(os.fspath(repo_path))
+            releases = [tag for tag, _ in _get_release_commits(repo, release_line)]
+            
+    assert "v23.04.2" not in releases
+    assert "v23.04.0" in releases


### PR DESCRIPTION
In order to get all tags from different branches by setting in `aiidalab-registry` with:

```
releases:
  - url: 'git+https://github.com/aiidalab/aiidalab-qe.git@_:v22.05.0^..'
```