### PR TITLE
Unpin MarkupSafe package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,8 +21,7 @@ classifiers =
 packages = find:
 install_requires =
     CacheControl~=0.12
-    Jinja2>=2.11.3,<4
-    MarkupSafe==2.0.1
+    Jinja2~=3.0
     cachetools~=4.1
     click>=7.0,<9
     click-spinner~=0.1


### PR DESCRIPTION
The pin was a workaround around an issue with an old Jinja 2.x version, but we have since then updated Jinja so it should not be neccessary anymore.

See https://github.com/aiidalab/aiidalab/pull/264 for details.

NOTE: This pin also prevents potential upgrade to Python 3.11