### PR TITLE
Add minimum Dependabot config to autoupdate GHA config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+---
+version: 2
+updates:
+# Maintain dependencies for GitHub Actions
+    - package-ecosystem: github-actions
+      directory: /
+      schedule:
+          interval: monthly


### PR DESCRIPTION
Making sure that GHA actions in workflows are up to date is a real chore. Let's try to use Dependabot to help with that.

Suggested by repo-review:

https://learn.scientific-python.org/development/guides/repo-review/?repo=aiidalab%2Faiidalab&branch=main

If this works here we can apply it to other repos as well.

NOTE: In this minimum configuration, dependabot should *not* manage Python dependencies.