### PR TITLE
Group Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,7 @@ updates:
       directory: /
       schedule:
           interval: monthly
+      groups:
+          gha-dependencies:
+              patterns:
+                  - '*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     - package-ecosystem: github-actions
       directory: /
       schedule:
-          interval: monthly
+          interval: daily
       groups:
           gha-dependencies:
               patterns:


### PR DESCRIPTION
Let's try config so that dependabot does not open separate PR for every individual GH action.