### PR TITLE
Use uv to install dependencies in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
             - main
     pull_request:
 
+env:
+    FORCE_COLOR: 1
+
 jobs:
 
     test-package:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
                   python-version: ${{ matrix.python-version }}
 
             - name: Install uv
-              run: curl -LsSf https://astral.sh/uv/install.sh | sh
+              run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.1.21/uv-installer.sh | sh
 
             - name: Install package with uv
               run: uv pip install --system -e .[dev]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
                   python-version: ${{ matrix.python-version }}
 
             - name: Install uv
-              run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.1.21/uv-installer.sh | sh
+              run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.1.31/uv-installer.sh | sh
 
             - name: Install package with uv
               run: uv pip install --system -e .[dev]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
                   python-version: ${{ matrix.python-version }}
 
             - name: Install uv
-              run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.1.31/uv-installer.sh | sh
+              run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.2.4/uv-installer.sh | sh
 
             - name: Install package with uv
               run: uv pip install --system -e .[dev]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,21 +1,13 @@
 ---
 name: CI
 
-on: [push, pull_request]
+on:
+    push:
+        branches:
+            - main
+    pull_request:
 
 jobs:
-
-    pre-commit:
-
-        runs-on: ubuntu-latest
-
-        steps:
-            - uses: actions/checkout@v4
-            - name: Set up Python 3.9
-              uses: actions/setup-python@v5
-              with:
-                  python-version: '3.10'
-            - uses: pre-commit/action@v3.0.1
 
     test-package:
         runs-on: ubuntu-latest
@@ -36,10 +28,11 @@ jobs:
               with:
                   python-version: ${{ matrix.python-version }}
 
-            - name: Install package
-              run: |
-                  pip install -e .[dev]
-                  pip freeze
+            - name: Install uv
+              run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+            - name: Install package with uv
+              run: uv pip install --system -e .[dev]
 
             - name: Run tests
               run: pytest -vs --cov

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,8 +51,6 @@ console_scripts =
 
 [options.extras_require]
 dev =
-    bumpver==2021.1114
-    pre-commit~=3.5
     pytest~=7.2.1
     pytest-cov~=4.0
 docs =

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,8 @@ console_scripts =
 
 [options.extras_require]
 dev =
+    bumpver==2021.1114
+    pre-commit~=3.5
     pytest~=7.2.1
     pytest-cov~=4.0
 docs =

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,8 +51,8 @@ console_scripts =
 
 [options.extras_require]
 dev =
-    bumpver==2021.1114
-    pre-commit~=3.5
+    bumpver>=2021.1114
+    pre-commit>=3.5
     pytest~=7.2.1
     pytest-cov~=4.0
 docs =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 import pytest
-import yaml
+from ruamel.yaml import YAML
 
 from aiidalab.app import AiidaLabApp, _AiidaLabApp
 
@@ -17,10 +17,11 @@ def generate_app(monkeypatch):
         watch=False,
     ):
         if app_data is None:
+            safe_yaml = YAML(typ="safe")
             with open(
                 Path(__file__).parent.absolute() / "static/app_registry.yaml"
             ) as f:
-                app_data = yaml.safe_load(f)
+                app_data = safe_yaml.load(f)
 
         # In the app_registry.yaml we defined the metadata which means
         # it is a installed app. Following monkeypatch make it more close


### PR DESCRIPTION
[uv](https://github.com/astral-sh/uv/issues/2155l) is the new cool kid in the town of Python packaging, from the creators of ruff. It currently serves as a much faster drop-in replacement for pip. 

For the `aiidalab` package, this drops installation time from ~15s to ~2s, which nearly halves the workflow time since the tests we have here are pretty quick.

Couple other small changes (feel free to push back)
 - Remove pre-commit section from CI since we use the pre-commit.ci anyway. 
 - Don't run tests on both push and pull_request event, this leads to duplication for pull requests coming from origin.
 - ~~remove bumpver and pre-commit from direct dev dependencies, as proposed [on Discourse](https://aiida.discourse.group/t/remove-pre-commit-and-bumpver-from-dev-dependencies/325)~~
 - get rid of incidental pyyaml dependency, see comment below