### PR TITLE
Remove ipython as a direct dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,6 @@ install_requires =
     click-spinner~=0.1
     dacite~=1.6
     dulwich~=0.20
-    ipython~=7.0
     jsonref~=0.2
     jsonschema[format]~=3.2
     packaging>=20.1,<22


### PR DESCRIPTION
The `aiidalab` package depends transitively on ipython via `traitlets`, but we do not use it directly in the package so we shouldn't pin its version in the package requirements.

This is currently a blocker for updating the base jupyter image to python 3.10/3.11 in https://github.com/aiidalab/aiidalab-docker-stack/pull/455