### PR TITLE
CI: Don't track coverage of tests/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
               run: uv pip install --system -e .[dev]
 
             - name: Run tests
-              run: pytest -vs --cov
+              run: pytest -vs --cov=aiidalab
 
             - name: Upload coverage reports to Codecov
               uses: codecov/codecov-action@v4

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Pipfile.lock
 requirements.txt_dev
 requirements.txt_stable
 .DS_Store
+.coverage


### PR DESCRIPTION
Currently the line coverage percentage is being artificially inflated by tracking coverage of tests themselves, i.e. the files in the tests/ folder. Let's be honest with ourselves and track what we care about.

Split from #431 so that we actually see coverage increase in that PR.