### PR TITLE
Support python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: ['3.8', '3.9', '3.10', '3.11']
+                python-version: ['3.8', '3.9', '3.11', '3.12']
 
         steps:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     tabulate~=0.8
     toml~=0.10
     traitlets~=5.0
-    watchdog~=2.3
+    watchdog~=4.0
 python_requires = >=3.8
 include_package_data = True
 zip_safe = False


### PR DESCRIPTION
Bumped watchdog dependency to support python 3.12
According to changelog there shouldn't be any breaking changes. 🤞