### PR TITLE
Drop support for old docker stack and Python-3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: ['3.8', '3.9', '3.10', '3.11']
+                python-version: ['3.9', '3.11', '3.12']
 
         steps:
 

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -42,7 +42,6 @@ from aiidalab.utils import (
     load_app_registry_index,
     run_pip_install,
     run_post_install_script,
-    run_reentry_scan,
     run_verdi_daemon_restart,
     split_git_url,
     this_or_only_subdir,
@@ -366,20 +365,6 @@ class _AiidaLabApp:
     def _install_dependencies(self, python_bin, stdout):
         """Try to install the app dependencies with pip (if specified)."""
 
-        def _should_run_reentry():
-            # We do not need to run reentry scan for aiida-core>=2"""
-            packages = find_installed_packages(python_bin=None)
-            installed_aiida = get_package_by_name(packages, "aiida-core")
-            # In practice this should never happen
-            if installed_aiida is None:
-                return False
-            aiida_v1 = Requirement("aiida-core<2.0.0b1")
-            # This is needed to handle pre-release versions such as 1.0.0b0
-            aiida_v1.specifier.prereleases = True
-            if installed_aiida.fulfills(aiida_v1):
-                return True
-            return False
-
         def _pip_install(*args, stdout):
             # The implementation of this function is taken and adapted from:
             # https://www.endpoint.com/blog/2015/01/getting-realtime-output-using-python/
@@ -393,23 +378,14 @@ class _AiidaLabApp:
             if process.returncode != 0:
                 raise RuntimeError("Failed to install dependencies.")
 
-            # AiiDA plugins require reentry run to be found by AiiDA.
-            if _should_run_reentry():
-                logger.info("\nRunning 'reentry scan'\n")
-                process = run_reentry_scan()
-                for line in io.TextIOWrapper(process.stdout, encoding="utf-8"):
-                    stdout.write(line)
-                process.wait()
-                if process.returncode != 0:
-                    # Let's not fail the install because of this, just emit a warning.
-                    logger.warning("'reentry scan' failed")
-
             # Restarting the AiiDA daemon to import newly installed plugins.
+            # TODO: Skip this if verdi is not available (useful for testing).
             process = run_verdi_daemon_restart()
             for line in io.TextIOWrapper(process.stdout, encoding="utf-8"):
                 stdout.write(line)
             process.wait()
             if process.returncode != 0:
+                # TODO: I don't think we should fail the installation if this step fails.
                 raise RuntimeError("Failed to restart verdi daemon.")
 
         for path in (self.path.joinpath(".aiidalab"), self.path):

--- a/aiidalab/utils.py
+++ b/aiidalab/utils.py
@@ -244,14 +244,6 @@ def run_pip_install(*args: Any, python_bin: str) -> Any:
     )
 
 
-def run_reentry_scan() -> Any:
-    return subprocess.Popen(
-        ["reentry", "scan"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-    )
-
-
 def run_verdi_daemon_restart() -> Any:
     # When installing or updating a plugin package, one needs to
     # restart the daemon with the ``--reset`` flag for changes to take effect.
@@ -269,6 +261,8 @@ def run_post_install_script(post_install_script_path: Path) -> Any:
     return subprocess.Popen(
         f"./{post_install_script_path.resolve().stem}",
         cwd=post_install_script_path.resolve().parent,
+        # TODO: We should redirect to a file (maybe post_install.out?"
+        # Otherwise any errors are impossible to debug.
         stdout=subprocess.DEVNULL,
         stderr=subprocess.STDOUT,
     )

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     toml~=0.10
     traitlets~=5.0
     watchdog~=2.3
-python_requires = >=3.8
+python_requires = >=3.9
 include_package_data = True
 zip_safe = False
 


### PR DESCRIPTION
Drop support for the old docker stack, which is no longer maintained (and hopefully not used anywhere!). We can then drop support for Python 3.8 since the new stack started with 3.9

This reverts relevant parts of #355.