### PR TITLE
Make auto-generated release notes nicer

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,25 @@
+---
+# Configuration for automatically generated release notes:
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes
+# We exclude PRs from bots and categorize PRs based on labels
+changelog:
+    exclude:
+        authors:
+            - dependabot
+            - pre-commit-ci
+    categories:
+        - title: Breaking Changes 🛠
+          labels:
+              - breaking
+        - title: New Features 🎉
+          labels:
+              - enhancement
+        - title: Bug fixes 🐛
+          labels:
+              - bug
+        - title: Documentation 📝
+          labels:
+              - documentation
+        - title: Other Changes
+          labels:
+              - '*'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,7 +94,7 @@ jobs:
                   name: release
                   path: dist/
 
-            - uses: softprops/action-gh-release@v2.0.6
+            - uses: softprops/action-gh-release@v2
               name: Create release
               if: startsWith(github.ref, 'refs/tags/v')
               with:


### PR DESCRIPTION
Adds a configuration for auto-generated release notes to make them a bit nicer:
- Exclude PRs from dependabot and pre-commit-ci bot
- Autogenerate sections based on PR labels.

I've already merged tested this in AWB https://github.com/aiidalab/aiidalab-widgets-base/pull/618 and it seems to work nicely, let's try it here as well.
