### PR TITLE
Fix segfault from requests_cache

### DIFF
--- a/aiidalab/utils.py
+++ b/aiidalab/utils.py
@@ -33,27 +33,27 @@ FIND_INSTALLED_PACKAGES_CACHE = TTLCache(maxsize=32, ttl=60)  # type: ignore
 # The cache is configured to avoid spamming the app registry server with requests
 # that are made in rapid succession and also serves as a fallback in case
 # that the index server is temporarily not reachable.
-session = CachedSession(
+_session = CachedSession(
     "aiidalab_registry",
     use_cache_dir=True,  # store cache in ~/.cache/
     backend="sqlite",
     expire_after=60,  # seconds
-    old_data_on_error=True,
+    stale_if_error=True,
 )
 
 
 def load_app_registry_index() -> Any:
     """Load apps' information from the AiiDAlab registry."""
     try:
-        return session.get(f"{AIIDALAB_REGISTRY}/apps_index.json").json()
+        return _session.get(f"{AIIDALAB_REGISTRY}/apps_index.json").json()
     except (ValueError, requests.ConnectionError) as error:
         raise RuntimeError("Unable to load registry index") from error
 
 
 def load_app_registry_entry(app_id: str) -> Any:
-    """Load registry enty for app with app_id."""
+    """Load registry entry for app with app_id."""
     try:
-        return session.get(f"{AIIDALAB_REGISTRY}/apps/{app_id}.json").json()
+        return _session.get(f"{AIIDALAB_REGISTRY}/apps/{app_id}.json").json()
     except (ValueError, requests.ConnectionError):
         logger.debug(f"Unable to load registry entry for app with id '{app_id}'.")
         return None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ from ruamel.yaml import YAML
 def static_path():
     import importlib.resources
 
-    return importlib.resources.files() / "static"
+    return importlib.resources.files(__name__) / "static"
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,18 +1,14 @@
 import sys
-from pathlib import Path
 
 import pytest
 from ruamel.yaml import YAML
 
-from aiidalab.app import AiidaLabApp, _AiidaLabApp
-
 
 @pytest.fixture(scope="session")
 def static_path():
-    # TODO: Switch to importlib.resources once we drop support for Python 3.8
-    # import importlib.resources
-    # return importlib.resources.files() / "static"
-    return Path(__file__).parent.absolute() / "static"
+    import importlib.resources
+
+    return importlib.resources.files() / "static"
 
 
 @pytest.fixture(scope="session")
@@ -40,6 +36,8 @@ def generate_app(monkeypatch, app_registry_path):
         app_data=None,
         watch=False,
     ):
+        from aiidalab.app import AiidaLabApp, _AiidaLabApp
+
         if app_data is None:
             safe_yaml = YAML(typ="safe")
             with app_registry_path.open() as f:
@@ -49,6 +47,7 @@ def generate_app(monkeypatch, app_registry_path):
         # it is a installed app. Following monkeypatch make it more close
         # to the real scenario for test.
         monkeypatch.setattr(_AiidaLabApp, "is_installed", lambda _: True)
+        monkeypatch.setattr(_AiidaLabApp, "is_registered", lambda _: True)
         app = AiidaLabApp(name, app_data, aiidalab_apps_path, watch=watch)
 
         return app
@@ -90,13 +89,10 @@ def forbid_external_commands(monkeypatch):
         lambda: raise_exc("Running `verdi daemon restart` not allowed in tests!"),
     )
 
-    # TODO: Enable this once the existing tests don't use it
-    """
     monkeypatch.setattr(
         "aiidalab.utils.load_app_registry_index",
-        lambda: raise_exc("Running fetching registry index not allowed in tests!"),
+        lambda: raise_exc("Fetching registry index not allowed in tests!"),
     )
-    """
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,6 +93,11 @@ def forbid_external_commands(monkeypatch):
         lambda: raise_exc("Fetching registry index not allowed in tests!"),
     )
 
+    monkeypatch.setattr(
+        "aiidalab.utils.load_app_registry_entry",
+        lambda _: raise_exc("Fetching app registry entry not allowed in tests!"),
+    )
+
 
 @pytest.fixture
 def installed_packages(monkeypatch):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import sys
+from pathlib import Path
 
 import pytest
 from ruamel.yaml import YAML
@@ -6,9 +7,7 @@ from ruamel.yaml import YAML
 
 @pytest.fixture(scope="session")
 def static_path():
-    import importlib.resources
-
-    return importlib.resources.files(__name__) / "static"
+    return Path(__file__).parent.absolute() / "static"
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_appclass.py
+++ b/tests/test_appclass.py
@@ -6,7 +6,7 @@ from time import sleep
 import pytest
 import traitlets
 
-from aiidalab.app import AiidaLabApp, AiidaLabAppWatch, _AiidaLabApp
+from aiidalab.app import AiidaLabApp, AiidaLabAppWatch
 
 
 def test_init_refresh(generate_app):
@@ -45,10 +45,10 @@ def test_dependencies(generate_app):
 @pytest.mark.usefixtures("installed_packages")
 def test_app_is_not_registered(generate_app, monkeypatch, tmp_path):
     """test the app is not registered and the available versions are empty."""
-    # monkeypatch and make the app not registered
-    monkeypatch.setattr(_AiidaLabApp, "is_registered", lambda _: False)
 
     app: AiidaLabApp = generate_app()
+    # monkeypatch and make the app not registered
+    monkeypatch.setattr(app._app, "is_registered", lambda: False)
     app.refresh()
 
     assert app.is_installed() is True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -103,10 +103,15 @@ def test_dry_install(aiidalab_env, static_path):
     assert "No apps installed" in result.output, result.output
 
 
-def test_install_uninstall(aiidalab_env, static_path):
+def test_install_uninstall(monkeypatch, aiidalab_env, static_path):
     """
     Test `aiidalab install` followed by `aiidalab uninstall`.
     """
+    monkeypatch.setattr(
+        "aiidalab.utils.load_app_registry_entry",
+        lambda _: None,
+    )
+
     aiidalab_apps = Path(aiidalab_env["AIIDALAB_APPS"])
     app_name = "hello-world"
     app_path = static_path / "app_with_setupcfg"

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -8,6 +8,8 @@ def test_forbidden_functions():
     and other functions that might influence global environment.
     """
     from aiidalab.utils import (
+        load_app_registry_entry,
+        load_app_registry_index,
         run_pip_install,
         run_post_install_script,
         run_verdi_daemon_restart,
@@ -24,3 +26,9 @@ def test_forbidden_functions():
     with pytest.raises(SystemExit):
         process = run_post_install_script("post_install")
         process.wait()
+
+    with pytest.raises(SystemExit):
+        load_app_registry_index()
+
+    with pytest.raises(SystemExit):
+        load_app_registry_entry("app")


### PR DESCRIPTION
As #196 explains, we now use a global cache for *all* `requests` calls! That's quite scary since it influences apps that import `aiidalab` package, such as AWB or home app! 

Here we fix this using the approach suggested in https://github.com/aiidalab/aiidalab/issues/196#issuecomment-899196469 Moreover, this seems to fix the segfault that we started seeing with `requests_cache>=1.0.0` described in #446.

Fixes #446 ( :crossed_fingers: ). Fixes #196 
Hopefully also fixes #413, I've removed the call to the app registry from tests.
 
### Testing 

Because we generally want to avoid fetching app index over network in tests, I've tested manually.

1. Launch a container with the latest `ghcr.io/aiidalab/full-stack:edge` image
2. Navigate to the app store page and observe that it crashes with "Kernel died" error, this is cause by the segfault described in #446 
3. Setup a dev environment with the help of aiidalab-dev
```
pip install git+https://github.com/aiidalab/aiidalab-dev
develop-aiidalab setup
```
4. Checkout this branch
```
cd local/aiidalab && git fetch origin fix-segfault && git switch fix-segfault
```
5. Now refresh the appstore page, it should now load.

Here's a script where you can reproduce the segfault from command line

```python
import logging
from home.app_store import AiidaLabAppStore    
      
logging.basicConfig(level='INFO')    
logging.getLogger('requests_cache').setLevel('DEBUG')    
      
store = AiidaLabAppStore()
```

TODO: Might be able to write a unit test with local file with either:
- https://pypi.org/project/requests-file/
- https://requests-mock.readthedocs.io/en/latest/index.html
- https://github.com/kiwicom/pytest-recording

### Debugging

Add logging calls to `aiidalab.utils.load_app_registry_index` or `load_app_registry_entry`:
```python
        response = _session.get(f"{AIIDALAB_REGISTRY}/apps_index.json")
        import time
        logger.info(f"Time: {time.ctime(int(time.time()))} Used cache: {response.from_cache}")
        return response.json()
```