### PR TITLE
Memoize _AiidaLabApp.is_registered()

### DIFF
--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -151,6 +151,10 @@ class _AiidaLabApp:
             local_registry_entry = cls._registry_entry_from_path(app_path)
             remote_registry_entry = load_app_registry_entry(app_id)
             registry_entry = remote_registry_entry or local_registry_entry
+            # If the caller did not tell us whether the app was registered or not,
+            # we can determine that here.
+            if registered is None:
+                registered = True if remote_registry_entry else False
 
         return cls.from_registry_entry(
             path=app_path, registry_entry=registry_entry, registered=registered
@@ -785,9 +789,13 @@ class AiidaLabApp(traitlets.HasTraits):
         app_data: dict[str, Any],
         aiidalab_apps_path: str,
         watch: bool = True,
+        registered: bool | None = None,
     ):
         self._app = _AiidaLabApp.from_id(
-            name, registry_entry=app_data, apps_path=aiidalab_apps_path
+            name,
+            registry_entry=app_data,
+            apps_path=aiidalab_apps_path,
+            registered=registered,
         )
         super().__init__()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,7 @@ def generate_app(monkeypatch, app_registry_path):
         aiidalab_apps_path="/tmp/apps",
         app_data=None,
         watch=False,
+        registered=True,
     ):
         from aiidalab.app import AiidaLabApp, _AiidaLabApp
 
@@ -46,8 +47,9 @@ def generate_app(monkeypatch, app_registry_path):
         # it is a installed app. Following monkeypatch make it more close
         # to the real scenario for test.
         monkeypatch.setattr(_AiidaLabApp, "is_installed", lambda _: True)
-        monkeypatch.setattr(_AiidaLabApp, "is_registered", lambda _: True)
-        app = AiidaLabApp(name, app_data, aiidalab_apps_path, watch=watch)
+        app = AiidaLabApp(
+            name, app_data, aiidalab_apps_path, watch=watch, registered=registered
+        )
 
         return app
 

--- a/tests/test_appclass.py
+++ b/tests/test_appclass.py
@@ -47,11 +47,9 @@ def test_dependencies(generate_app):
 
 @pytest.mark.usefixtures("installed_packages")
 def test_app_is_not_registered(generate_app, monkeypatch, tmp_path):
-    """test the app is not registered and the available versions are empty."""
+    """test that if app is not registered, the available versions are empty."""
 
-    app: AiidaLabApp = generate_app()
-    # monkeypatch and make the app not registered
-    monkeypatch.setattr(app._app, "is_registered", lambda: False)
+    app: AiidaLabApp = generate_app(registered=False)
     app.refresh()
 
     assert app.is_installed() is True

--- a/tests/test_appdataclass.py
+++ b/tests/test_appdataclass.py
@@ -78,12 +78,12 @@ def test_invalid_requirements_skipped():
 def test_find_dependencies_to_install(monkeypatch, installed_packages, python_bin):
     """Test find_dependencies_to_install method of _AiidaLabApp.
     By mocking the _AiidallabApp class with its attributes set."""
-    monkeypatch.setattr(_AiidaLabApp, "is_registered", lambda _: True)
 
     aiidalab_app_data = _AiidaLabApp(
         metadata={},
         name="test",
         path=Path("test"),
+        _registered=True,
         releases={
             "stable": {
                 "environment": {
@@ -125,13 +125,9 @@ def test_update_status_of_unregistred_app(
     # The path need to be exist otherwise the app considered to be not installed, in the test
     # we monkeypatch in as installed.
     monkeypatch.setattr(_AiidaLabApp, "is_installed", lambda _: True)
-    monkeypatch.setattr(_AiidaLabApp, "is_registered", lambda _: False)
 
     aiidalab_app_data = _AiidaLabApp(
-        metadata={},
-        name="test",
-        path=tmp_path,
-        releases={},
+        metadata={}, name="test", path=tmp_path, releases={}, _registered=False
     )
 
     assert (
@@ -144,7 +140,6 @@ def test_update_status_latest_version_incompatible(
     monkeypatch, installed_packages, python_bin
 ):
     """Test issue #360 where when the highest version is core dependencies unmet and hidden."""
-    monkeypatch.setattr(_AiidaLabApp, "is_registered", lambda _: True)
     monkeypatch.setattr(_AiidaLabApp, "is_installed", lambda _: True)
     monkeypatch.setattr(_AiidaLabApp, "installed_version", lambda _: "v0.1.0")
 
@@ -152,6 +147,7 @@ def test_update_status_latest_version_incompatible(
         metadata={},
         name="test",
         path=Path("test"),
+        _registered=True,
         releases={
             "v0.2.0": {
                 "environment": {
@@ -184,12 +180,12 @@ def test_compatibility_check_with_local_repo_if_detached(
     from aiidalab.environment import Environment
 
     monkeypatch.setattr(_AiidaLabApp, "is_installed", lambda _: True)
-    monkeypatch.setattr(_AiidaLabApp, "is_registered", lambda _: True)
 
     aiidalab_app_data = _AiidaLabApp(
         metadata={},
         name="test",
         path=tmp_path,
+        _registered=True,
         releases={},
     )
 


### PR DESCRIPTION
Currently, whether an App is registered in the App Store or not is determined via `_AiidaLabAppis_registered()` method, which **always** fetches the app index to determine this. Even though we use `requests_cache` to cache the HTTP request, this is still wasteful (especially in App Store where this method is called for all the apps). I think it is a fair assumption that the registered status will not change during the lifetime of the Python process, so we can determine it once and store it as a class attribute. This is what is done in this PR.

Moreover, in the specific case of App Store page, the whole index is fetched first and then we create `_AiidaLabApp` instances for all the apps in the index. In this case, we already know that the apps are registered, so we can simply pass this info via class constructor. (This change will need to be implemented in `aiidalab-home` after this is merged and released).

Follow up to #447, where the fact that we've been fetching the app index so many times was triggering a bug in `requests_cache`.

TODO: Update existing tests.