### PR TITLE
Update watchdog dependency 

### DIFF
--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -27,7 +27,11 @@ from uuid import uuid4
 import requests
 import traitlets
 from dulwich.errors import NotGitRepository
-from watchdog.events import EVENT_TYPE_OPENED, FileSystemEventHandler
+from watchdog.events import (
+    EVENT_TYPE_CLOSED_NO_WRITE,
+    EVENT_TYPE_OPENED,
+    FileSystemEventHandler,
+)
 from watchdog.observers import Observer
 from watchdog.observers.polling import PollingObserver
 
@@ -624,7 +628,7 @@ class AiidaLabAppWatch:
 
         def on_any_event(self, event: FileSystemEvent) -> None:
             """Refresh app for any event except opened."""
-            if event.event_type != EVENT_TYPE_OPENED:
+            if event.event_type not in (EVENT_TYPE_OPENED, EVENT_TYPE_CLOSED_NO_WRITE):
                 self.app.refresh_async()
 
     def __init__(self, app: AiidaLabApp):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "tabulate~=0.8",
     "toml~=0.10",
     "traitlets~=5.0",
-    "watchdog~=4.0",
+    "watchdog~=6.0",
 ]
 description = "Implements core functions of AiiDAlab"
 license = {file = 'LICENSE'}


### PR DESCRIPTION
### Context 

We use `watchdog` to monitor file events in app's directories so that we can potentially modify app's status immediately. (This is very cool although I think this is perhaps overengineered given a relatively niche use-case). See screencast below for a demonstration

### Motivation

Starting with version v5 watchdog library is now fully typed, which will help us towards #363. was released recently.

[Changelog for v5](https://github.com/gorakhargosh/watchdog/releases/tag/v5.0.0). 
[Changelog for v6](https://github.com/gorakhargosh/watchdog/releases/tag/v6.0.0). 

There is one change in the code to ignore the newly added `EVENT_TYPE_CLOSED_NO_WRITE` event which we do not care about

Citing from the inotify(7) manpage,

>   IN_CLOSE_NOWRITE is fired when a file
      that was opened in read-only mode was closed.

Since we only watch for events that (potentially) modify files inside the app git repo, we can ignore this event.

### Test plan

See screencast. NOTE: I've verified that the double-refresh is an pre-existing issue that's unrelated to this PR.

[Screencast from 2026-04-10 10-12-42.webm](https://github.com/user-attachments/assets/bf246cdc-02fd-49ed-a560-15d4eb7f13f5)
