### PR TITLE
Replacing pkg_resource with importlib

### DIFF
--- a/aiidalab/__main__.py
+++ b/aiidalab/__main__.py
@@ -586,22 +586,27 @@ def uninstall(
 
 @contextmanager
 def _mock_schemas_endpoints() -> Generator[None, None, None]:
-    import pkg_resources
+    import importlib.resources as resources
+
     import requests_mock
 
     schema_paths = [
-        path
-        for path in pkg_resources.resource_listdir(f"{__package__}.registry", "schemas")
-        if path.endswith(".schema.json")
+        path.name
+        for path in resources.files(f"{__package__}.registry")
+        .joinpath("schemas")
+        .iterdir()
+        if path.is_file() and path.name.endswith(".schema.json")
     ]
 
     with requests_mock.Mocker(real_http=True) as mocker:
         for schema_path in schema_paths:
-            schema = json.loads(
-                pkg_resources.resource_string(
-                    f"{__package__}.registry", f"schemas/{schema_path}"
-                )
+            schema_file = (
+                resources.files(f"{__package__}.registry")
+                .joinpath("schemas")
+                .joinpath(schema_path)
             )
+            with schema_file.open("rb") as f:
+                schema = json.loads(f.read())
             mocker.get(
                 schema.get("$id", f"{SCHEMAS_CANONICAL_BASE_URL}/{schema_path}"),
                 text=json.dumps(schema),

--- a/aiidalab/__main__.py
+++ b/aiidalab/__main__.py
@@ -591,7 +591,7 @@ def _mock_schemas_endpoints() -> Generator[None, None, None]:
     import requests_mock
 
     schema_paths = [
-        path.name
+        path
         for path in resources.files(f"{__package__}.registry")
         .joinpath("schemas")
         .iterdir()
@@ -600,15 +600,9 @@ def _mock_schemas_endpoints() -> Generator[None, None, None]:
 
     with requests_mock.Mocker(real_http=True) as mocker:
         for schema_path in schema_paths:
-            schema_file = (
-                resources.files(f"{__package__}.registry")
-                .joinpath("schemas")
-                .joinpath(schema_path)
-            )
-            with schema_file.open("rb") as f:
-                schema = json.loads(f.read())
+            schema = json.loads(schema_path.read_bytes())
             mocker.get(
-                schema.get("$id", f"{SCHEMAS_CANONICAL_BASE_URL}/{schema_path}"),
+                schema.get("$id", f"{SCHEMAS_CANONICAL_BASE_URL}/{schema_path.name}"),
                 text=json.dumps(schema),
             )
         yield


### PR DESCRIPTION
issue #432 

Replaced the deprecated `pkg_resources` module with `importlib.resources` .
This update ensure compatibility with newer Python versions and removes the unnecessary dependency on `setuptools`.