### PR TITLE
Add citation handler

### DIFF
--- a/aiidalab/metadata.py
+++ b/aiidalab/metadata.py
@@ -91,6 +91,8 @@ def _parse_setup_cfg(
         categories = [c for c in categories.split("\n") if c]
     yield "categories", categories
 
+    yield "citations", metadata_pep426.get("citation", "").splitlines()
+
 
 @dataclass
 class Metadata:
@@ -105,6 +107,7 @@ class Metadata:
     logo: None | str = None
     categories: list[str] = field(default_factory=list)
     version: None | str = None
+    citations: list[str] = field(default_factory=list)
 
     _search_dirs = (".aiidalab", "./")
 

--- a/aiidalab/registry/static/static/css/style.css
+++ b/aiidalab/registry/static/static/css/style.css
@@ -90,6 +90,10 @@ h2 .category {
     color: #333;
 }
 
+.citations {
+    margin: 0;
+}
+
 .details {
     margin-top: 12px;
 }

--- a/aiidalab/registry/templates/app_page_base.html
+++ b/aiidalab/registry/templates/app_page_base.html
@@ -75,6 +75,17 @@
     </div>
     {% endif %}
 
+    {%if metadata and metadata.citation %}
+    <h2>
+        Citations
+    </h2>
+    <ul id='citations'>
+    {% for citation in metadata.citations %}
+        <li>{{ citation }}</li>
+    {% endfor %}
+    </ul>
+    {% endif %}
+
 </main>
 
 {% endblock body %}


### PR DESCRIPTION
This PR adds a citation handler to the app base page:

```
    {%if metadata and metadata.citation %}
    <h2>
        Citation
    </h2>
    <div id='citation'>
        {{ metadata.citation }}
    </div>
    {% endif %}
```

as well as to metadata.py (`Metadata` dataclass and parser). This allows the following:

<img width="1192" height="467" alt="image" src="https://github.com/user-attachments/assets/90ec269c-7f19-4831-b82b-38b9b7b24955" />
