### PR TITLE
Pin setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "pip",
     "requests~=2.27",
     "requests-cache~=1.0",
-    "setuptools",
+    "setuptools<82.0",
     "tabulate~=0.8",
     "toml~=0.10",
     "traitlets~=5.0",


### PR DESCRIPTION
setuptools 82.0 removed the deprecated `pkg_resources` modules. https://setuptools.pypa.io/en/latest/history.html#v82-0-0 Until we migrate, we need to pin to an older versions.

The `pkg_resources` migration is tracked in #432, and there's an open PR #474 