### PR TITLE
App installation should not require daemon restart to succeed

### DIFF
--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -430,14 +430,12 @@ class _AiidaLabApp:
                 raise RuntimeError(msg)
 
             # Restarting the AiiDA daemon to import newly installed plugins.
-            # TODO: Skip this if verdi is not available (useful for testing).
             process = run_verdi_daemon_restart()
             for line in io.TextIOWrapper(process.stdout, encoding="utf-8"):
                 stdout.write(line)
             process.wait()
             if process.returncode != 0:
-                # TODO: I don't think we should fail the installation if this step fails.
-                raise RuntimeError("Failed to restart verdi daemon.")
+                logger.warning("Failed to restart verdi daemon.")
 
         for path in (self.path.joinpath(".aiidalab"), self.path):
             if path.exists():


### PR DESCRIPTION
Currently, we issue the `verdi daemon restart` command immediately after an app is installed.
That is needed so that the daemon workers pick up any new plugins. 
However, we now error if the `verdi daemon restart` returns an error, and revert the whole installation, which is a very frustrating outcome. 

Note that in practice that means that the app installation always fails when a deamon is not running because, somewhat questionably, `verdi daemon restart` errors out in that case). 

Here instead of throwing an error we just log a warning. 

Closes #441

### Test plan

#### Behaviour before this PR

```console
$ verdi daemon stop
$ aiidalab install aurora --yes
Collecting apps matching requirements... Done.

Installation plan:

  App     Version    Path
  ------  ---------  ------------------------
  aurora  0.12.3     /home/jovyan/apps/aurora
...
...
Successfully installed aurora-0.12.3
Critical: daemon is not running
WARNING:aiidalab.app:Removing partially installed app.
Error: Failed to install 'aurora' (version=0.12.3) at '/home/jovyan/apps/aurora'
Hint: Use `aiidalab -v install` to display full stack trace
```

#### This PR

```console
$ verdi daemon stop
$ aiidalab install aurora --yes
Collecting apps matching requirements... Done.

Installation plan:

  App     Version    Path
  ------  ---------  ------------------------
  aurora  0.12.3     /home/jovyan/apps/aurora
...
...
Successfully installed aurora-0.12.3 pandas-1.5.3
Critical: daemon is not running
WARNING:aiidalab.app:Failed to restart verdi daemon.
Installed 'aurora' version '0.12.3'.
```