### PR TITLE
Add ipywidgets to core-packages

### DIFF
--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -59,7 +59,11 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_CORE_PACKAGES = [Package("aiida-core"), Package("jupyter-client")]
+_CORE_PACKAGES = [
+    Package("aiida-core"),
+    Package("jupyter-client"),
+    Package("ipywidgets"),
+]
 
 
 # A version is usually of type str, but it can also be a value

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,6 +56,7 @@ def generate_app(monkeypatch, app_registry_path):
 
 _MONKEYPATCHED_INSTALLED_PACKAGES = [
     {"name": "aiida-core", "version": "2.2.1"},
+    {"name": "ipywidgets", "version": "7.6.0"},
     {"name": "jupyter_client", "version": "7.3.5"},
 ]
 


### PR DESCRIPTION
In aiidalab we have a concept of core packages which must never be re-installed in the image. Up till now that was just `aiida-core` and `jupyter-client`. Before we even show an app on Appstore page, which check that a given app version does not have package requirements that would conflict with the core packages, and if they do, we don't show the version at all to the user. Let's add ipywidgets to this list, so that users don't try to install older package versions to the new nbclassic-based image. (note that we already pin ipywidgets in the image, so even if the user tried the installation, it would ultimately fail). 

## Test plan

The following has been tested in the nbclassic image (`ghcr.io/aiidalab/full-stack:pr-479`)

### Before this PR

Before this PR, in the Appstore one can try to install AWB 2.5.0

<img width="1474" height="512" alt="image" src="https://github.com/user-attachments/assets/d4aaa151-69dc-4c76-ac45-d6260c5d316f" />

The installation itself fails since we pin the ipywidgets version to v8 in the nbclassic docker image.

<img width="1612" height="477" alt="image" src="https://github.com/user-attachments/assets/9938c76f-0b8f-41a5-aecd-4d8271803ff1" />


### On this PR

<img width="1472" height="652" alt="image" src="https://github.com/user-attachments/assets/858cea52-4896-4e6d-9787-501c8c8f0a9d" />
