### PR TITLE
Add `citations` key to `metadata` schema

### DIFF
--- a/aiidalab/metadata.py
+++ b/aiidalab/metadata.py
@@ -94,7 +94,7 @@ def _parse_setup_cfg(
         categories = [c for c in categories.split("\n") if c]
     yield "categories", categories
 
-    yield "citations", metadata_pep426.get("citation", "").splitlines()
+    yield "citations", metadata_pep426.get("citations", "").splitlines()
 
 
 @dataclass

--- a/aiidalab/metadata.py
+++ b/aiidalab/metadata.py
@@ -94,7 +94,8 @@ def _parse_setup_cfg(
         categories = [c for c in categories.split("\n") if c]
     yield "categories", categories
 
-    yield "citations", metadata_pep426.get("citations", "").splitlines()
+    citations = aiidalab.get("citations", metadata_pep426.get("citations", ""))
+    yield "citations", citations.splitlines()
 
 
 @dataclass

--- a/aiidalab/registry/schemas/app.schema.json
+++ b/aiidalab/registry/schemas/app.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://raw.githubusercontent.com/aiidalab/aiidalab/v26.04.0/aiidalab/registry/schemas/app.schema.json",
+    "$id": "https://raw.githubusercontent.com/edan-bainglass/aiidalab/refs/heads/fix-citations-handler/aiidalab/registry/schemas/app.schema.json",
     "$ref": "#/definitions/App",
     "definitions": {
         "App": {

--- a/aiidalab/registry/schemas/app.schema.json
+++ b/aiidalab/registry/schemas/app.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://raw.githubusercontent.com/aiidalab/aiidalab/v21.10.0/aiidalab/registry/schemas/app.schema.json",
+    "$id": "https://raw.githubusercontent.com/aiidalab/aiidalab/v26.04.0/aiidalab/registry/schemas/app.schema.json",
     "$ref": "#/definitions/App",
     "definitions": {
         "App": {

--- a/aiidalab/registry/schemas/app.schema.json
+++ b/aiidalab/registry/schemas/app.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://raw.githubusercontent.com/edan-bainglass/aiidalab/refs/heads/fix-citations-handler/aiidalab/registry/schemas/app.schema.json",
+    "$id": "https://raw.githubusercontent.com/aiidalab/aiidalab/v26.04.0/aiidalab/registry/schemas/app.schema.json",
     "$ref": "#/definitions/App",
     "definitions": {
         "App": {

--- a/aiidalab/registry/schemas/apps.schema.json
+++ b/aiidalab/registry/schemas/apps.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://raw.githubusercontent.com/edan-bainglass/aiidalab/refs/heads/fix-citations-handler/aiidalab/registry/schemas/apps.schema.json",
+    "$id": "https://raw.githubusercontent.com/aiidalab/aiidalab/v26.04.0/aiidalab/registry/schemas/apps.schema.json",
     "$ref": "#/definitions/Apps",
     "definitions": {
         "App": {

--- a/aiidalab/registry/schemas/apps.schema.json
+++ b/aiidalab/registry/schemas/apps.schema.json
@@ -1,13 +1,13 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://raw.githubusercontent.com/aiidalab/aiidalab/v21.10.0/aiidalab/registry/schemas/apps.schema.json",
+    "$id": "https://raw.githubusercontent.com/aiidalab/aiidalab/v26.04.0/aiidalab/registry/schemas/apps.schema.json",
     "$ref": "#/definitions/Apps",
     "definitions": {
         "App": {
             "type": "object",
             "properties": {
                 "releases": {
-                    "$ref": "#definitions/ReleaseSpecifications"
+                    "$ref": "#/definitions/ReleaseSpecifications"
                 }
             },
             "additionalProperties": false,
@@ -39,7 +39,7 @@
 		    "$ref": "metadata.schema.json#/definitions/Welcome"
                 },
                 "url": {
-                    "$ref": "#definitions/ReleaseSpecificationUrl"
+                    "$ref": "#/definitions/ReleaseSpecificationUrl"
                 },
                 "version": {
                     "type": "string"
@@ -58,10 +58,10 @@
             "items": {
                 "oneOf": [
                     {
-                        "$ref": "#definitions/ReleaseSpecification"
+                        "$ref": "#/definitions/ReleaseSpecification"
                     },
                     {
-                        "$ref": "#definitions/ReleaseSpecificationUrl"
+                        "$ref": "#/definitions/ReleaseSpecificationUrl"
                     }
                 ]
             }

--- a/aiidalab/registry/schemas/apps.schema.json
+++ b/aiidalab/registry/schemas/apps.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://raw.githubusercontent.com/aiidalab/aiidalab/v26.04.0/aiidalab/registry/schemas/apps.schema.json",
+    "$id": "https://raw.githubusercontent.com/edan-bainglass/aiidalab/refs/heads/fix-citations-handler/aiidalab/registry/schemas/apps.schema.json",
     "$ref": "#/definitions/Apps",
     "definitions": {
         "App": {

--- a/aiidalab/registry/schemas/apps_index.schema.json
+++ b/aiidalab/registry/schemas/apps_index.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://raw.githubusercontent.com/aiidalab/aiidalab/v26.04.0/aiidalab/registry/schemas/apps_index.schema.json",
+    "$id": "https://raw.githubusercontent.com/edan-bainglass/aiidalab/refs/heads/fix-citations-handler/aiidalab/registry/schemas/apps_index.schema.json",
     "$ref": "#/definitions/AppsAndCategories",
     "definitions": {
         "AppsAndCategories": {

--- a/aiidalab/registry/schemas/apps_index.schema.json
+++ b/aiidalab/registry/schemas/apps_index.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://raw.githubusercontent.com/aiidalab/aiidalab/v21.10.0/aiidalab/registry/schemas/apps_index.schema.json",
+    "$id": "https://raw.githubusercontent.com/aiidalab/aiidalab/v26.04.0/aiidalab/registry/schemas/apps_index.schema.json",
     "$ref": "#/definitions/AppsAndCategories",
     "definitions": {
         "AppsAndCategories": {

--- a/aiidalab/registry/schemas/apps_index.schema.json
+++ b/aiidalab/registry/schemas/apps_index.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://raw.githubusercontent.com/edan-bainglass/aiidalab/refs/heads/fix-citations-handler/aiidalab/registry/schemas/apps_index.schema.json",
+    "$id": "https://raw.githubusercontent.com/aiidalab/aiidalab/v26.04.0/aiidalab/registry/schemas/apps_index.schema.json",
     "$ref": "#/definitions/AppsAndCategories",
     "definitions": {
         "AppsAndCategories": {

--- a/aiidalab/registry/schemas/metadata.schema.json
+++ b/aiidalab/registry/schemas/metadata.schema.json
@@ -60,6 +60,12 @@
                 },
                 "version": {
                     "type": "string"
+                },
+                "citations": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             },
             "additionalProperties": false,

--- a/aiidalab/registry/templates/app_page_base.html
+++ b/aiidalab/registry/templates/app_page_base.html
@@ -75,7 +75,7 @@
     </div>
     {% endif %}
 
-    {%if metadata and metadata.citation %}
+    {%if metadata and metadata.citations %}
     <h2>
         Citations
     </h2>


### PR DESCRIPTION
Missed in #488

### Changes

- [x] Add `citations` entry to metadata schema
- [x] Fix typo in `citations` extraction from metadata
- [x] Fix schema URLs to upcoming 26.04.0 release

@danielhollas tests won't pass, as there is no 26.04.0 release, we need to merge and release 26.04.0. IMO, this system is far from ideal. Unclear what the rational was behind it. Let's discuss to see if it can be improved.

Note that I am still trying to figure out how to test this locally. Need to go through the docs.