### PR TITLE
Only install compatible packages during app update

### DIFF
--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -537,10 +537,10 @@ class _AiidaLabApp:
         post_install_triggers: bool = True,
     ) -> None:
         if version is None:
-            versions = sort_semantic(self.releases, prereleases=prereleases)
-            if len(versions) == 0:
+            try:
+                version = next(self.available_versions(prereleases=prereleases))
+            except StopIteration:
                 raise ValueError(f"No versions available for '{self}'.")
-            version = versions[0]
         if python_bin is None:
             python_bin = sys.executable
 
@@ -900,8 +900,6 @@ class AiidaLabApp(traitlets.HasTraits):
             # Installing with version=None automatically selects latest
             # available version.
             version = self.install_app(version=None, stdout=stdout)
-            FIND_INSTALLED_PACKAGES_CACHE.clear()
-            self.refresh()
             return version
 
     def uninstall_app(self) -> None:


### PR DESCRIPTION
This was apparently an oversight when we implemented the filtering of packages based on whether they satisfy core dependencies (e.g. aiida-core).

When we run update, we passed `version=None` to `_AiidaLabApp.install()` in which case that method was supposed to pick the latest available version, but it was not using the proper filtering.

Closes #500 

## Test plan

See issue #500. Install AWB 2.4.0 first, and then go to App management page (http://localhost:8888/apps/apps/home/single_app.ipynb), tick the "pre-releases" box and click "Update button". The Update should pick up version 2.5.0 on this PR, while it picks 3.0.0a0 on main. 