### PR TITLE
Remove the deprecated `--reset` flag to `verdi daemon restart`

### DIFF
--- a/aiidalab/utils.py
+++ b/aiidalab/utils.py
@@ -275,13 +275,8 @@ def run_pip_install(*args: Any, python_bin: str) -> Any:
 
 
 def run_verdi_daemon_restart() -> Any:
-    # When installing or updating a plugin package, one needs to
-    # restart the daemon with the ``--reset`` flag for changes to take effect.
-    # Note, in the latest aiida-core branch, this is now the default.
-    # We need to remove "--reset" from the command to avoid an error
-    # in the future if the flag is removed.
     return subprocess.Popen(
-        ["verdi", "daemon", "restart", "--reset"],
+        ["verdi", "daemon", "restart"],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
     )


### PR DESCRIPTION
This was removed in aiida-core 2.6.0 since it is now the default behaviour
https://github.com/aiidateam/aiida-core/blob/main/CHANGELOG.md#changes
> CLI: Always do hard reset in verdi daemon restart [[8ac642410]](https://github.com/aiidateam/aiida-core/commit/8ac6424108d1528bd3279c81da62dd44855b6ebc)

We're do a daemon restart at the end of App installation, and this now generates a deprecation warning. So let's remove the flag!