### PR TITLE
Fix schema versions

### DIFF
--- a/aiidalab/metadata.py
+++ b/aiidalab/metadata.py
@@ -95,7 +95,7 @@ def _parse_setup_cfg(
     yield "categories", categories
 
     citations = aiidalab.get("citations", metadata_pep426.get("citations", ""))
-    yield "citations", citations.splitlines()
+    yield "citations", [c for c in citations.splitlines() if c]
 
 
 @dataclass

--- a/aiidalab/metadata.py
+++ b/aiidalab/metadata.py
@@ -101,14 +101,22 @@ def _parse_setup_cfg(
 
 
 @dataclass
-class Citation:
-    """App citation specification."""
+class SimpleCitation:
+    """App citation specification for free-form text with an optional link."""
+
+    text: str
+    link: str | None = None
+
+
+@dataclass
+class StandardCitation:
+    """App citation specification for structured metadata."""
 
     authors: list[str]
-    title: str
     journal: str
     year: str
     doi: str
+    title: str | None = None
     issue: str | None = None
     volume: str | None = None
 
@@ -126,7 +134,7 @@ class Metadata:
     logo: None | str = None
     categories: list[str] = field(default_factory=list)
     version: None | str = None
-    citations: list[Citation] = field(default_factory=list)
+    citations: list[SimpleCitation | StandardCitation] = field(default_factory=list)
 
     _search_dirs = (".aiidalab", "./")
 

--- a/aiidalab/metadata.py
+++ b/aiidalab/metadata.py
@@ -49,6 +49,8 @@ def _parse_setup_cfg(
     setup_cfg: str,
 ) -> Generator[tuple[str, str | list[str]], None, None]:
     "Parse a setup.cfg configuration file string for metadata."
+    import json
+
     cfg = ConfigParser()
     cfg.read_string(setup_cfg)
 
@@ -94,8 +96,21 @@ def _parse_setup_cfg(
         categories = [c for c in categories.split("\n") if c]
     yield "categories", categories
 
-    citations = aiidalab.get("citations", metadata_pep426.get("citations", ""))
-    yield "citations", [c for c in citations.splitlines() if c]
+    citations = aiidalab.get("citations", metadata_pep426.get("citations", []))
+    yield "citations", json.loads(citations)
+
+
+@dataclass
+class Citation:
+    """App citation specification."""
+
+    authors: list[str]
+    title: str
+    journal: str
+    year: str
+    doi: str
+    issue: str | None = None
+    volume: str | None = None
 
 
 @dataclass
@@ -111,7 +126,7 @@ class Metadata:
     logo: None | str = None
     categories: list[str] = field(default_factory=list)
     version: None | str = None
-    citations: list[str] = field(default_factory=list)
+    citations: list[Citation] = field(default_factory=list)
 
     _search_dirs = (".aiidalab", "./")
 

--- a/aiidalab/metadata.py
+++ b/aiidalab/metadata.py
@@ -96,7 +96,7 @@ def _parse_setup_cfg(
         categories = [c for c in categories.split("\n") if c]
     yield "categories", categories
 
-    citations = aiidalab.get("citations", metadata_pep426.get("citations", []))
+    citations = aiidalab.get("citations", metadata_pep426.get("citations", "[]"))
     yield "citations", json.loads(citations)
 
 

--- a/aiidalab/registry/schemas/app.schema.json
+++ b/aiidalab/registry/schemas/app.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://raw.githubusercontent.com/aiidalab/aiidalab/refs/heads/main/aiidalab/registry/schemas/app.schema.json",
+    "$id": "https://raw.githubusercontent.com/edan-bainglass/aiidalab/refs/heads/fix-schema-versions/aiidalab/registry/schemas/app.schema.json",
     "$ref": "#/definitions/App",
     "definitions": {
         "App": {

--- a/aiidalab/registry/schemas/app.schema.json
+++ b/aiidalab/registry/schemas/app.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://raw.githubusercontent.com/aiidalab/aiidalab/v26.04.0/aiidalab/registry/schemas/app.schema.json",
+    "$id": "https://raw.githubusercontent.com/aiidalab/aiidalab/refs/heads/main/aiidalab/registry/schemas/app.schema.json",
     "$ref": "#/definitions/App",
     "definitions": {
         "App": {

--- a/aiidalab/registry/schemas/app.schema.json
+++ b/aiidalab/registry/schemas/app.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://raw.githubusercontent.com/edan-bainglass/aiidalab/refs/heads/fix-schema-versions/aiidalab/registry/schemas/app.schema.json",
+    "$id": "https://raw.githubusercontent.com/aiidalab/aiidalab/v26.05.1/aiidalab/registry/schemas/app.schema.json",
     "$ref": "#/definitions/App",
     "definitions": {
         "App": {

--- a/aiidalab/registry/schemas/apps.schema.json
+++ b/aiidalab/registry/schemas/apps.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://raw.githubusercontent.com/aiidalab/aiidalab/refs/heads/main/aiidalab/registry/schemas/apps.schema.json",
+    "$id": "https://raw.githubusercontent.com/edan-bainglass/aiidalab/refs/heads/fix-schema-versions/aiidalab/registry/schemas/apps.schema.json",
     "$ref": "#/definitions/Apps",
     "definitions": {
         "App": {

--- a/aiidalab/registry/schemas/apps.schema.json
+++ b/aiidalab/registry/schemas/apps.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://raw.githubusercontent.com/edan-bainglass/aiidalab/refs/heads/fix-schema-versions/aiidalab/registry/schemas/apps.schema.json",
+    "$id": "https://raw.githubusercontent.com/aiidalab/aiidalab/v26.05.1/aiidalab/registry/schemas/apps.schema.json",
     "$ref": "#/definitions/Apps",
     "definitions": {
         "App": {

--- a/aiidalab/registry/schemas/apps.schema.json
+++ b/aiidalab/registry/schemas/apps.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://raw.githubusercontent.com/aiidalab/aiidalab/v26.04.0/aiidalab/registry/schemas/apps.schema.json",
+    "$id": "https://raw.githubusercontent.com/aiidalab/aiidalab/refs/heads/main/aiidalab/registry/schemas/apps.schema.json",
     "$ref": "#/definitions/Apps",
     "definitions": {
         "App": {

--- a/aiidalab/registry/schemas/apps_index.schema.json
+++ b/aiidalab/registry/schemas/apps_index.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://raw.githubusercontent.com/aiidalab/aiidalab/v26.04.0/aiidalab/registry/schemas/apps_index.schema.json",
+    "$id": "https://raw.githubusercontent.com/aiidalab/aiidalab/refs/heads/main/aiidalab/registry/schemas/apps_index.schema.json",
     "$ref": "#/definitions/AppsAndCategories",
     "definitions": {
         "AppsAndCategories": {

--- a/aiidalab/registry/schemas/apps_index.schema.json
+++ b/aiidalab/registry/schemas/apps_index.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://raw.githubusercontent.com/aiidalab/aiidalab/refs/heads/main/aiidalab/registry/schemas/apps_index.schema.json",
+    "$id": "https://raw.githubusercontent.com/edan-bainglass/aiidalab/refs/heads/fix-schema-versions/aiidalab/registry/schemas/apps_index.schema.json",
     "$ref": "#/definitions/AppsAndCategories",
     "definitions": {
         "AppsAndCategories": {

--- a/aiidalab/registry/schemas/apps_index.schema.json
+++ b/aiidalab/registry/schemas/apps_index.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://raw.githubusercontent.com/edan-bainglass/aiidalab/refs/heads/fix-schema-versions/aiidalab/registry/schemas/apps_index.schema.json",
+    "$id": "https://raw.githubusercontent.com/aiidalab/aiidalab/v26.05.1/aiidalab/registry/schemas/apps_index.schema.json",
     "$ref": "#/definitions/AppsAndCategories",
     "definitions": {
         "AppsAndCategories": {

--- a/aiidalab/registry/schemas/metadata.schema.json
+++ b/aiidalab/registry/schemas/metadata.schema.json
@@ -64,7 +64,7 @@
                 "citations": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/Citation"
                     }
                 }
             },
@@ -74,6 +74,41 @@
                 "title"
             ],
             "title": "Welcome"
+        },
+        "Citation": {
+            "type": "object",
+            "properties": {
+                "authors": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "title": {
+                    "type": "string"
+                },
+                "journal": {
+                    "type": "string"
+                },
+                "volume": {
+                    "type": "string"
+                },
+                "year": {
+                    "type": "string"
+                },
+                "doi": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "authors",
+                "title",
+                "journal",
+                "year",
+                "doi"
+            ],
+            "title": "Citation"
         }
     }
 }

--- a/aiidalab/registry/schemas/metadata.schema.json
+++ b/aiidalab/registry/schemas/metadata.schema.json
@@ -64,7 +64,10 @@
                 "citations": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/Citation"
+                        "oneOf": [
+                            {"$ref": "#/definitions/CitationSimple"},
+                            {"$ref": "#/definitions/CitationStandard"}
+                        ]
                     }
                 }
             },
@@ -75,7 +78,24 @@
             ],
             "title": "Welcome"
         },
-        "Citation": {
+        "CitationSimple": {
+            "type": "object",
+            "properties": {
+                "text": {
+                    "type": "string"
+                },
+                "link": {
+                    "type": "string",
+                    "format": "uri"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "text"
+            ],
+            "title": "CitationSimple"
+        },
+        "CitationStandard": {
             "type": "object",
             "properties": {
                 "authors": {
@@ -84,13 +104,7 @@
                         "type": "string"
                     }
                 },
-                "title": {
-                    "type": "string"
-                },
                 "journal": {
-                    "type": "string"
-                },
-                "volume": {
                     "type": "string"
                 },
                 "year": {
@@ -98,17 +112,25 @@
                 },
                 "doi": {
                     "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "volume": {
+                    "type": "string"
+                },
+                "issue": {
+                    "type": "string"
                 }
             },
             "additionalProperties": false,
             "required": [
                 "authors",
-                "title",
                 "journal",
                 "year",
                 "doi"
             ],
-            "title": "Citation"
+            "title": "CitationStandard"
         }
     }
 }

--- a/aiidalab/registry/templates/app_page_base.html
+++ b/aiidalab/registry/templates/app_page_base.html
@@ -81,7 +81,15 @@
     </h2>
     <ul id='citations'>
     {% for citation in metadata.citations %}
-        <li>{{ citation }}</li>
+        <li>
+            {{ citation.authors | join(", ") }},
+            "{{ citation.title }}".
+            <em>{{ citation.journal }}</em>
+            {% if citation.volume %} <b>{{ citation.volume }}</b>{% endif %}
+            {% if citation.issue %}, {{ citation.issue }}{% endif %}
+            ({{ citation.year }}).
+            <a href="https://doi.org/{{ citation.doi }}" target="_blank" noreferrer noopener>https://doi.org/{{ citation.doi }}</a>
+        </li>
     {% endfor %}
     </ul>
     {% endif %}

--- a/aiidalab/registry/templates/app_page_base.html
+++ b/aiidalab/registry/templates/app_page_base.html
@@ -82,13 +82,27 @@
     <ul id='citations'>
     {% for citation in metadata.citations %}
         <li>
-            {{ citation.authors | join(", ") }},
-            "{{ citation.title }}".
-            <em>{{ citation.journal }}</em>
-            {% if citation.volume %} <b>{{ citation.volume }}</b>{% endif %}
-            {% if citation.issue %}, {{ citation.issue }}{% endif %}
-            ({{ citation.year }}).
-            <a href="https://doi.org/{{ citation.doi }}" target="_blank" noreferrer noopener>https://doi.org/{{ citation.doi }}</a>
+            {% if citation.text %}
+                {% if citation.link %}
+                    <a href="{{ citation.link }}" target="_blank" noreferrer noopener>{{ citation.text }}</a>
+                {% else %}
+                    {{ citation.text }}
+                {% endif %}
+            {% else %}
+                {{ citation.authors | join(", ") }},
+                {% if citation.title %}
+                    "{{ citation.title }}".
+                {% endif %}
+                <em>{{ citation.journal }}</em>
+                {% if citation.volume %}
+                    , <b>{{ citation.volume }}</b>
+                {% endif %}
+                {% if citation.issue %}
+                    , {{ citation.issue }}
+                {% endif %}
+                ({{ citation.year }}).
+                <a href="https://doi.org/{{ citation.doi }}" target="_blank" noreferrer noopener>https://doi.org/{{ citation.doi }}</a>
+            {% endif %}
         </li>
     {% endfor %}
     </ul>


### PR DESCRIPTION
#499 didn't fully handle citations correctly/safely. Here, I add a proper Citation schema and update the handler (backend/frontend).

Schemas are pinned for now to the involved branches (here, in the registry repo, and in the QE app, which I'm using as a tester). Once all is well, schemas should pin to... TBD (see#505).

<img width="1204" height="491" alt="image" src="https://github.com/user-attachments/assets/1a9e3312-d40e-467b-87d2-bcddeaaff2b5" />

### Update

This PR adds dedicated dataclasses to represent two citation flavors:

```python
@dataclass
class SimpleCitation:
    """App citation specification for free-form text with an optional link."""

    text: str
    link: str | None = None


@dataclass
class StandardCitation:
    """App citation specification for structured metadata."""

    authors: list[str]
    journal: str
    year: str
    doi: str
    title: str | None = None
    issue: str | None = None
    volume: str | None = None
```

Citations are consumed via a either a plugin's `[aiidalab]` or `[metadata]` sections in an app's setup.cfg (aiidalab first):
```
    citations = aiidalab.get("citations", metadata_pep426.get("citations", "[]"))
    yield "citations", json.loads(citations)
```

Citations can be overridden via apps.yaml (no change here).

Example from the QE app:

```
[aiidalab]
title = Quantum ESPRESSO
description = The Quantum ESPRESSO (QE) app is a web-based interface within AiiDAlab that allows users to perform first-principles calculations and analyze material properties (e.g., band structures) directly from their browser.
citations =
    [
      {
        "authors": ["Wang, X.", "Bainglass, E.", "Bonacci, M.", "Ortega-Guerrero, A.", "et al."],
        "title": "Making atomistic materials calculations accessible with the AiiDAlab Quantum ESPRESSO app",
        "journal": "npj Comput. Mater.",
        "volume": "12",
        "pages": "72",
        "year": "2026",
        "doi": "10.1038/s41524-025-01936-4"
      }
    ]
categories =
    quantum
```