### PR TITLE
Fix citations metadata handling

### DIFF
--- a/aiidalab/metadata.py
+++ b/aiidalab/metadata.py
@@ -96,8 +96,11 @@ def _parse_setup_cfg(
         categories = [c for c in categories.split("\n") if c]
     yield "categories", categories
 
-    citations = aiidalab.get("citations", metadata_pep426.get("citations", "[]"))
-    yield "citations", json.loads(citations)
+    citations = aiidalab.get("citations", metadata_pep426.get("citations"))
+    try:
+        yield "citations", json.loads(str(citations))
+    except json.JSONDecodeError:
+        yield "citations", []
 
 
 @dataclass


### PR DESCRIPTION
@danielhollas had to add a guard around the citation handler due to a failure. Now, the failure is actually due to the QE app still having the old style format (string style) and was crashing the build. Even though I have since PR'd the updated format there, I think this guard is good in general to have.