### PR TITLE
Add citations property to `AiidaLabApp` class

### DIFF
--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -1030,6 +1030,10 @@ class AiidaLabApp(traitlets.HasTraits):
         return self._get_from_metadata("external_url")
 
     @property
+    def citations(self) -> str:
+        return self._get_from_metadata("citations")
+
+    @property
     def more(self) -> str:
         return f"""<a href=./single_app.ipynb?app={self.name}>Manage App</a>"""
 


### PR DESCRIPTION
Extracted from app metadata, which routes through the setup.cfg aiidalab section.
This is used, for example, in the home app's app manager to display app citations.