### PR TITLE
Uninstall python package during app removal

### DIFF
--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -324,10 +324,13 @@ class _AiidaLabApp:
             or self.path.joinpath("pyproject.toml").is_file()
         ):
             logger.info(f"Running 'pip uninstall --user {self.name}'")
-            process = run_pip_uninstall(str(self.path), python_bin=python_bin)
-            for line in io.TextIOWrapper(process.stdout, encoding="utf-8"):
-                logger.warning(line)
+            process = run_pip_uninstall(str(self.name), python_bin=python_bin)
             process.wait()
+            for line in io.TextIOWrapper(process.stdout, encoding="utf-8"):
+                if process.returncode == 0:
+                    logger.info(line)
+                else:
+                    logger.warning(line)
             if process.returncode != 0:
                 msg = f"pip failed to uninstall python package {self.name}"
                 logger.warning(msg)

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -323,11 +323,13 @@ class _AiidaLabApp:
             self.path.joinpath("setup.py").is_file()
             or self.path.joinpath("pyproject.toml").is_file()
         ):
-            logger.info(f"Running 'pip uninstall --user {self.path}'")
+            logger.info(f"Running 'pip uninstall --user {self.name}'")
             process = run_pip_uninstall(str(self.path), python_bin=python_bin)
+            for line in io.TextIOWrapper(process.stdout, encoding="utf-8"):
+                logger.warning(line)
             process.wait()
             if process.returncode != 0:
-                msg = "pip failed to uninstall app python package"
+                msg = f"pip failed to uninstall python package {self.name}"
                 logger.warning(msg)
 
     def find_matching_releases(

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -327,13 +327,9 @@ class _AiidaLabApp:
             process = run_pip_uninstall(str(self.name), python_bin=python_bin)
             process.wait()
             for line in io.TextIOWrapper(process.stdout, encoding="utf-8"):
-                if process.returncode == 0:
-                    logger.info(line)
-                else:
-                    logger.warning(line)
+                logger.info(line)
             if process.returncode != 0:
-                msg = f"pip failed to uninstall python package {self.name}"
-                logger.warning(msg)
+                logger.info(f"pip failed to uninstall python package {self.name}")
 
     def find_matching_releases(
         self, specifier: SpecifierSet, prereleases: bool | None = None

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -47,6 +47,7 @@ from .utils import (
     get_package_by_name,
     is_valid_version,
     run_pip_install,
+    run_pip_uninstall,
     run_post_install_script,
     run_verdi_daemon_restart,
     sort_semantic,
@@ -303,11 +304,31 @@ class _AiidaLabApp:
         self._move_to_trash()
         trash_path.rename(self.path)
 
-    def uninstall(self, move_to_trash: bool = True) -> None:
+    def uninstall(
+        self, move_to_trash: bool = True, python_bin: str | None = None
+    ) -> None:
+        if python_bin is None:
+            python_bin = sys.executable
+        # Uninstall the app python package first
+        # (this will not uninstall its dependencies!)
+        self._uninstall_python_package(python_bin)
+
         if move_to_trash:
             self._move_to_trash()
         else:
             shutil.rmtree(self.path)
+
+    def _uninstall_python_package(self, python_bin: str) -> None:
+        if (
+            self.path.joinpath("setup.py").is_file()
+            or self.path.joinpath("pyproject.toml").is_file()
+        ):
+            logger.info(f"Running 'pip uninstall --user {self.path}'")
+            process = run_pip_uninstall(str(self.path), python_bin=python_bin)
+            process.wait()
+            if process.returncode != 0:
+                msg = "pip failed to uninstall app python package"
+                logger.warning(msg)
 
     def find_matching_releases(
         self, specifier: SpecifierSet, prereleases: bool | None = None

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -47,6 +47,7 @@ from .utils import (
     get_package_by_name,
     is_valid_version,
     run_pip_install,
+    run_pip_uninstall,
     run_post_install_script,
     run_verdi_daemon_restart,
     sort_semantic,
@@ -303,11 +304,32 @@ class _AiidaLabApp:
         self._move_to_trash()
         trash_path.rename(self.path)
 
-    def uninstall(self, move_to_trash: bool = True) -> None:
+    def uninstall(
+        self, move_to_trash: bool = True, python_bin: str | None = None
+    ) -> None:
+        if python_bin is None:
+            python_bin = sys.executable
+        # Uninstall the app python package first
+        # (this will not uninstall its dependencies!)
+        self._uninstall_python_package(python_bin)
+
         if move_to_trash:
             self._move_to_trash()
         else:
             shutil.rmtree(self.path)
+
+    def _uninstall_python_package(self, python_bin: str) -> None:
+        if (
+            self.path.joinpath("setup.py").is_file()
+            or self.path.joinpath("pyproject.toml").is_file()
+        ):
+            logger.info(f"Running 'pip uninstall --user {self.name}'")
+            process = run_pip_uninstall(str(self.name), python_bin=python_bin)
+            process.wait()
+            for line in io.TextIOWrapper(process.stdout, encoding="utf-8"):
+                logger.info(line)
+            if process.returncode != 0:
+                logger.info(f"pip failed to uninstall python package {self.name}")
 
     def find_matching_releases(
         self, specifier: SpecifierSet, prereleases: bool | None = None

--- a/aiidalab/utils.py
+++ b/aiidalab/utils.py
@@ -281,7 +281,7 @@ def run_pip_install(*args: Any, python_bin: str) -> Any:
 
 def run_pip_uninstall(*args: Any, python_bin: str) -> Any:
     return subprocess.Popen(
-        [python_bin, "-m", "pip", "uninstall", "--user", *args],
+        [python_bin, "-m", "pip", "uninstall", "--yes", *args],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
     )

--- a/aiidalab/utils.py
+++ b/aiidalab/utils.py
@@ -279,6 +279,14 @@ def run_pip_install(*args: Any, python_bin: str) -> Any:
     )
 
 
+def run_pip_uninstall(*args: Any, python_bin: str) -> Any:
+    return subprocess.Popen(
+        [python_bin, "-m", "pip", "uninstall", "--user", *args],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+
 def run_verdi_daemon_restart() -> Any:
     return subprocess.Popen(
         ["verdi", "daemon", "restart"],

--- a/aiidalab/utils.py
+++ b/aiidalab/utils.py
@@ -277,6 +277,14 @@ def run_pip_install(*args: Any, python_bin: str) -> Any:
     )
 
 
+def run_pip_uninstall(*args: Any, python_bin: str) -> Any:
+    return subprocess.Popen(
+        [python_bin, "-m", "pip", "uninstall", "--yes", *args],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+
 def run_verdi_daemon_restart() -> Any:
     return subprocess.Popen(
         ["verdi", "daemon", "restart"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
     "pip>=25.2",
     "requests~=2.27",
     "requests-cache~=1.0",
-    "setuptools>=68.0,<82.0",
     "tabulate~=0.9",
     "toml~=0.10",
     "traitlets~=5.0",
@@ -55,6 +54,7 @@ dev = [
     "types-click-spinner~=0.1",
 ]
 registry = [
+    "setuptools>=68.0,<82.0",
     "CacheControl~=0.12",
     "jsonref~=0.2",
     "jsonschema[format]~=3.2",


### PR DESCRIPTION
Currently, when an app is being uninstalled, the only thing we do is to remove the app directory (the git repo in `/home/jovyan/apps/<app-name>`). We don't remove the apps python package (if any) or any of its python dependencies. 

Removing apps python dependencies would be unsafe, since they can be shared with other apps, but we can safely remove the python package of the app itself, since keeping it around is (at the very least) confusing. This is what this PR implements. 

Note, this is only done on a best-effort basis, since the app name might not be the same as python package name. Notably, this is the case for QeApp, where the app name is `quantum-espresso`, while the python package is `aiidalab-qe`. Perhaps we can special case QeApp here?

Closes #405 

### Test plan

1. Tested in CI on aiidalab-docker-stack repo: https://github.com/aiidalab/aiidalab-docker-stack/pull/571

2. Manual testing

```console
$ aiidalab install --yes aurora

$ pip show aurora
Name: aurora
Version: 0.12.3
Summary: An AiiDAlab application for the Aurora BIG-MAP Stakeholder initiative.
Home-page: https://github.com/EmpaEconversion/aiidalab-aurora
Author: Edan Bainglass, Francisco F. Ramirez, Loris Ercole, Giovanni Pizzi
Author-email: edan.bainglass@psi.ch
License: 
Location: /home/jovyan/.local/lib/python3.9/site-packages
Requires: aiida-aurora, aiidalab, dgbowl-schemas, ipyfilechooser, ipympl, ipywidgets, numpy, pandas, pydantic, seaborn
Required-by:
$ aiidalab uninstall --yes aurora
Collecting apps to uninstall... Done.

Would uninstall:

  App name    Version    Path
  ----------  ---------  ------------------------
  aurora      0.12.3     /home/jovyan/apps/aurora

  ▬:detached •:modified

Uninstalled 'aurora' ('/home/jovyan/apps/aurora').
$ pip show aurora
WARNING: Package(s) not found: aurora
```