### PR TITLE
Move setuptools dep into registry extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
     "pip>=25.2",
     "requests~=2.27",
     "requests-cache~=1.0",
-    "setuptools>=68.0,<82.0",
     "tabulate~=0.9",
     "toml~=0.10",
     "traitlets~=5.0",
@@ -55,6 +54,7 @@ dev = [
     "types-click-spinner~=0.1",
 ]
 registry = [
+    "setuptools>=68.0,<82.0",
     "CacheControl~=0.12",
     "jsonref~=0.2",
     "jsonschema[format]~=3.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dev = [
     "types-click-spinner~=0.1",
 ]
 registry = [
-    "setuptools>=68.0,<82.0",
+    "setuptools>=65.0,<82.0",
     "CacheControl~=0.12",
     "jsonref~=0.2",
     "jsonschema[format]~=3.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dev = [
     "types-click-spinner~=0.1",
 ]
 registry = [
-    "setuptools>=65.0,<82.0",
+    "setuptools>=68.0,<82.0",
     "CacheControl~=0.12",
     "jsonref~=0.2",
     "jsonschema[format]~=3.2",


### PR DESCRIPTION
`pkg_resources`, which is a subpackage of setuptools, is only used in the `aiidalab.registry` submodule so we can safely move it to the `registry` extras. 

This change makes the in-progress PR that removes this dependency (#474) much less pressing.