### PR TITLE
Fix metadata schema

### DIFF
--- a/aiidalab/metadata.py
+++ b/aiidalab/metadata.py
@@ -122,6 +122,7 @@ class StandardCitation:
     title: str | None = None
     issue: str | None = None
     volume: str | None = None
+    pages: str | None = None
 
 
 @dataclass

--- a/aiidalab/registry/schemas/app.schema.json
+++ b/aiidalab/registry/schemas/app.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://raw.githubusercontent.com/aiidalab/aiidalab/v26.05.1/aiidalab/registry/schemas/app.schema.json",
+    "$id": "https://raw.githubusercontent.com/edan-bainglass/aiidalab/refs/heads/fix-citations-metadata/aiidalab/registry/schemas/app.schema.json",
     "$ref": "#/definitions/App",
     "definitions": {
         "App": {

--- a/aiidalab/registry/schemas/app.schema.json
+++ b/aiidalab/registry/schemas/app.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://raw.githubusercontent.com/edan-bainglass/aiidalab/refs/heads/fix-citations-metadata/aiidalab/registry/schemas/app.schema.json",
+    "$id": "https://raw.githubusercontent.com/aiidalab/aiidalab/v26.06.1/aiidalab/registry/schemas/app.schema.json",
     "$ref": "#/definitions/App",
     "definitions": {
         "App": {

--- a/aiidalab/registry/schemas/apps.schema.json
+++ b/aiidalab/registry/schemas/apps.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://raw.githubusercontent.com/aiidalab/aiidalab/v26.05.1/aiidalab/registry/schemas/apps.schema.json",
+    "$id": "https://raw.githubusercontent.com/edan-bainglass/aiidalab/refs/heads/fix-citations-metadata/aiidalab/registry/schemas/apps.schema.json",
     "$ref": "#/definitions/Apps",
     "definitions": {
         "App": {

--- a/aiidalab/registry/schemas/apps.schema.json
+++ b/aiidalab/registry/schemas/apps.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://raw.githubusercontent.com/edan-bainglass/aiidalab/refs/heads/fix-citations-metadata/aiidalab/registry/schemas/apps.schema.json",
+    "$id": "https://raw.githubusercontent.com/aiidalab/aiidalab/v26.06.1/aiidalab/registry/schemas/apps.schema.json",
     "$ref": "#/definitions/Apps",
     "definitions": {
         "App": {

--- a/aiidalab/registry/schemas/apps_index.schema.json
+++ b/aiidalab/registry/schemas/apps_index.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://raw.githubusercontent.com/aiidalab/aiidalab/v26.05.1/aiidalab/registry/schemas/apps_index.schema.json",
+    "$id": "https://raw.githubusercontent.com/edan-bainglass/aiidalab/refs/heads/fix-citations-metadata/aiidalab/registry/schemas/apps_index.schema.json",
     "$ref": "#/definitions/AppsAndCategories",
     "definitions": {
         "AppsAndCategories": {

--- a/aiidalab/registry/schemas/apps_index.schema.json
+++ b/aiidalab/registry/schemas/apps_index.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://raw.githubusercontent.com/edan-bainglass/aiidalab/refs/heads/fix-citations-metadata/aiidalab/registry/schemas/apps_index.schema.json",
+    "$id": "https://raw.githubusercontent.com/aiidalab/aiidalab/v26.06.1/aiidalab/registry/schemas/apps_index.schema.json",
     "$ref": "#/definitions/AppsAndCategories",
     "definitions": {
         "AppsAndCategories": {

--- a/aiidalab/registry/schemas/metadata.schema.json
+++ b/aiidalab/registry/schemas/metadata.schema.json
@@ -64,7 +64,7 @@
                 "citations": {
                     "type": "array",
                     "items": {
-                        "oneOf": [
+                        "anyOf": [
                             {"$ref": "#/definitions/CitationSimple"},
                             {"$ref": "#/definitions/CitationStandard"}
                         ]
@@ -120,6 +120,9 @@
                     "type": "string"
                 },
                 "issue": {
+                    "type": "string"
+                },
+                "pages": {
                     "type": "string"
                 }
             },


### PR DESCRIPTION
The last 1-2 PRs regarding the new citations field in the metadata schema sadly made two mistakes:
1. We have two citation flavors: simple and standard. The schema defined citations as `oneOf` these - should be `anyOf`
2. The standard citation was missing the `pages` field

This PR fixes both. It temporarily points the schema ids to the fork to make sure tests pass. 

⚠️**Before merging**⚠️ point schemas to the upcoming patch release (v26.06.1)