### PR TITLE
Add py.typed marker, fix some type annotations

### DIFF
--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -778,8 +778,8 @@ class AiidaLabApp(traitlets.HasTraits):
     def __init__(
         self,
         name: str,
-        app_data: dict[str, Any],
-        aiidalab_apps_path: str,
+        app_data: dict[str, Any] | None,
+        aiidalab_apps_path: str | None,
         watch: bool = True,
     ):
         self._app = _AiidaLabApp.from_id(

--- a/aiidalab/py.typed
+++ b/aiidalab/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561


### PR DESCRIPTION
While I was looking into adding type annotations to aiidalab-home, I noticed 2 things:

1. aiidalab package was not declaring itself to be type-annotated (per [PEP 561](https://peps.python.org/pep-0561/#packaging-type-information)
2. Two type annotations were wrong (not allowing None values)