### PR TITLE
Update to ruff 0.16.1, use only default ruff rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,11 +13,11 @@ repos:
           - id: trailing-whitespace
 
     - repo: https://github.com/astral-sh/ruff-pre-commit
-      rev: v0.15.20
+      rev: v0.16.1
       hooks:
           - id: ruff-format
             exclude: ^docs/.*
-          - id: ruff
+          - id: ruff-check
             args: [--fix, --exit-non-zero-on-fix, --show-fixes]
 
     - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt

--- a/aiidalab/__main__.py
+++ b/aiidalab/__main__.py
@@ -132,7 +132,7 @@ def search(app_query: str, prereleases: bool) -> None:
                 raise click.ClickException(str(error))
             app_requirements = [
                 Requirement(app_name)
-                for app_name in registry["apps"].keys()
+                for app_name in registry["apps"]
                 if fnmatch(app_name, app_query)
             ]
 
@@ -590,7 +590,7 @@ def uninstall(
 
 @contextmanager
 def _mock_schemas_endpoints() -> Generator[None, None, None]:
-    import importlib.resources as resources
+    from importlib import resources
 
     import requests_mock
 

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -723,7 +723,7 @@ class AiidaLabAppWatch:
         if self._monitor_thread is not None:
             self._monitor_thread_stop.set()
 
-    def is_alive(self) -> bool | None | Thread:
+    def is_alive(self) -> bool | Thread | None:
         """Return True if this watch is still alive."""
         return self._monitor_thread and self._monitor_thread.is_alive()
 

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -218,7 +218,7 @@ class _AiidaLabApp:
                     if urlsplit(release["url"]).scheme.startswith("git+")
                 }
             # TODO: Use less-broad Exception here!
-            except Exception as error:
+            except Exception as error:  # noqa: BLE001
                 logger.warning(f"Encountered error while determining version: {error}")
                 return AppVersion.UNKNOWN
 
@@ -350,9 +350,7 @@ class _AiidaLabApp:
         packages = find_installed_packages(python_bin)
         for requirement in requirements:
             pkg = get_package_by_name(packages, requirement.name)
-            if pkg is None:
-                yield requirement
-            elif not pkg.fulfills(requirement):
+            if pkg is None or not pkg.fulfills(requirement):
                 yield requirement
 
     def is_detached(self) -> bool:
@@ -490,28 +488,28 @@ class _AiidaLabApp:
     def _install_from_path(self, path: Path) -> None:
         if path.is_dir():
             shutil.copytree(this_or_only_subdir(path), self.path)
-        else:
-            with tempfile.TemporaryDirectory() as tmp_dir:
-                with tarfile.open(path) as tar_file:
+            return
 
-                    def is_within_directory(directory: str, target: str) -> bool:
-                        abs_directory = os.path.abspath(directory)
-                        abs_target = os.path.abspath(target)
+        with tempfile.TemporaryDirectory() as tmp_dir, tarfile.open(path) as tar_file:
 
-                        prefix = os.path.commonprefix([abs_directory, abs_target])
+            def is_within_directory(directory: str, target: str) -> bool:
+                abs_directory = os.path.abspath(directory)
+                abs_target = os.path.abspath(target)
 
-                        return prefix == abs_directory
+                prefix = os.path.commonprefix([abs_directory, abs_target])
 
-                    def safe_extract(tar: tarfile.TarFile, path: str) -> None:
-                        for member in tar.getmembers():
-                            member_path = os.path.join(path, member.name)
-                            if not is_within_directory(path, member_path):
-                                raise Exception("Attempted Path Traversal in Tar File")  # noqa: TRY002
+                return prefix == abs_directory
 
-                        tar.extractall(path)
+            def safe_extract(tar: tarfile.TarFile, path: str) -> None:
+                for member in tar.getmembers():
+                    member_path = os.path.join(path, member.name)
+                    if not is_within_directory(path, member_path):
+                        raise Exception("Attempted Path Traversal in Tar File")  # noqa: TRY002
 
-                    safe_extract(tar_file, path=tmp_dir)
-                    self._install_from_path(Path(tmp_dir))
+                tar.extractall(path)
+
+            safe_extract(tar_file, path=tmp_dir)
+            self._install_from_path(Path(tmp_dir))
 
     def _install_from_https(self, url: str) -> None:
         response = requests.get(url, stream=True)
@@ -584,7 +582,7 @@ class _AiidaLabApp:
 
         # NOTE: We want to catch everything, including keyboard interrupt,
         # so we can rollback incomplete installation.
-        except BaseException as error:
+        except BaseException as error:  # noqa: BLE001
             try:
                 if trash_path is None:
                     # App, was not previously installed, just remove it.
@@ -973,27 +971,22 @@ class AiidaLabApp(traitlets.HasTraits):
     @throttled(calls_per_second=1)
     def refresh(self) -> None:
         """Refresh app state."""
-        with self._show_busy():
-            with self.hold_trait_notifications():
-                self._refresh_versions()
-                self._refresh_dependencies_to_install()
-                self.set_trait(
-                    "compatible", self._is_compatible(self.installed_version)
-                )
-                self.set_trait(
-                    "remote_update_status",
-                    self._app.remote_update_status(
-                        prereleases=self.include_prereleases
-                    ),
-                )
-                self.set_trait(
-                    "detached",
-                    (
-                        (self.installed_version is AppVersion.UNKNOWN)
-                        if (self._has_git_repo() and self._app.is_registered())
-                        else None
-                    ),
-                )
+        with self._show_busy(), self.hold_trait_notifications():
+            self._refresh_versions()
+            self._refresh_dependencies_to_install()
+            self.set_trait("compatible", self._is_compatible(self.installed_version))
+            self.set_trait(
+                "remote_update_status",
+                self._app.remote_update_status(prereleases=self.include_prereleases),
+            )
+            self.set_trait(
+                "detached",
+                (
+                    (self.installed_version is AppVersion.UNKNOWN)
+                    if (self._has_git_repo() and self._app.is_registered())
+                    else None
+                ),
+            )
 
     def refresh_async(self) -> None:
         """Asynchronized (non-blocking) refresh of the app state."""

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -568,7 +568,7 @@ class _AiidaLabApp:
                     urlunsplit(split_url._replace(scheme="https"))
                 )
             else:
-                raise NotImplementedError(  # noqa: TRY301
+                raise NotImplementedError(
                     f"Unsupported scheme: {split_url.scheme} ({url})"
                 )
 
@@ -602,7 +602,7 @@ class _AiidaLabApp:
                 raise RuntimeError(msg) from error
 
 
-class AppNotInstalledException(Exception):  # noqa: N818
+class AppNotInstalledException(Exception):
     pass
 
 

--- a/aiidalab/config.py
+++ b/aiidalab/config.py
@@ -1,8 +1,10 @@
 """Module to manage AiiDAlab configuration."""
 
+from __future__ import annotations
+
 from os import getenv
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 import click
 import toml
@@ -25,7 +27,7 @@ def _as_env_var_name(key: str) -> str:
     return "AIIDALAB_" + key.upper()
 
 
-def _get_config_value(key: str, default: Optional[str] = None) -> Any:
+def _get_config_value(key: str, default: str | None = None) -> Any:
     """Return config value from configuration source.
 
     The standard configuration source order is:

--- a/aiidalab/metadata.py
+++ b/aiidalab/metadata.py
@@ -131,13 +131,13 @@ class Metadata:
 
     title: str
     description: str
-    authors: None | str = None
-    state: None | str = None
-    documentation_url: None | str = None
-    external_url: None | str = None
-    logo: None | str = None
+    authors: str | None = None
+    state: str | None = None
+    documentation_url: str | None = None
+    external_url: str | None = None
+    logo: str | None = None
     categories: list[str] = field(default_factory=list)
-    version: None | str = None
+    version: str | None = None
     citations: list[SimpleCitation | StandardCitation] = field(default_factory=list)
 
     _search_dirs = (".aiidalab", "./")

--- a/aiidalab/metadata.py
+++ b/aiidalab/metadata.py
@@ -55,10 +55,10 @@ def _parse_setup_cfg(
     cfg.read_string(setup_cfg)
 
     metadata_pep426: SectionProxy | dict[Any, Any] = (
-        cfg["metadata"] if "metadata" in cfg else {}
+        cfg["metadata"] if "metadata" in cfg else {}  # noqa: SIM401
     )
     aiidalab: SectionProxy | dict[Any, Any] = (
-        cfg["aiidalab"] if "aiidalab" in cfg else {}
+        cfg["aiidalab"] if "aiidalab" in cfg else {}  # noqa: SIM401
     )
 
     yield "title", aiidalab.get("title", metadata_pep426.get("name", ""))

--- a/aiidalab/registry/releases.py
+++ b/aiidalab/registry/releases.py
@@ -97,7 +97,7 @@ def _get_release_commits(
 
         tags = set()
         remote_ref = Ref(b"refs/remotes/origin/")
-        for branch in repo.refs.as_dict(remote_ref).keys():
+        for branch in repo.refs.as_dict(remote_ref).keys():  # noqa: SIM118
             rev = branch.decode()
             rev_selection = match.groupdict()["rev_selection"]
 

--- a/aiidalab/registry/web.py
+++ b/aiidalab/registry/web.py
@@ -1,5 +1,7 @@
 """Generate the app registry website."""
 
+from __future__ import annotations
+
 import logging
 import os
 import os.path
@@ -7,7 +9,6 @@ import shutil
 from collections.abc import Generator
 from itertools import chain
 from pathlib import Path
-from typing import Optional
 
 import pkg_resources
 
@@ -68,10 +69,10 @@ def build(
     apps_path: Path,
     categories_path: Path,
     base_path: Path,
-    html_path: Optional[Path] = None,
-    api_path: Optional[Path] = None,
-    static_path: Optional[Path] = None,
-    templates_path: Optional[Path] = None,
+    html_path: Path | None = None,
+    api_path: Path | None = None,
+    static_path: Path | None = None,
+    templates_path: Path | None = None,
     validate_output: bool = True,
     validate_input: bool = False,
 ) -> None:
@@ -133,6 +134,5 @@ def build(
     ):
         logger.info(f"  - {outfile.relative_to(base_path)}")
 
-    if validate_output:
-        if api_path:
-            api.validate_api_v1(api_path=base_path / api_path, schemas=schemas)
+    if validate_output and api_path:
+        api.validate_api_v1(api_path=base_path / api_path, schemas=schemas)

--- a/aiidalab/utils.py
+++ b/aiidalab/utils.py
@@ -112,7 +112,7 @@ def parse_app_repo(
         }
 
 
-class throttled:  # noqa: N801
+class throttled:
     """Decorator to throttle calls to a function to a specified rate.
 
     The throttle is specific to the first argument of the wrapped

--- a/aiidalab/utils.py
+++ b/aiidalab/utils.py
@@ -77,8 +77,6 @@ def load_app_registry_entry(app_id: str) -> Any:
 class PEP508CompliantUrl(str):
     """Represents a PEP 508 compliant URL."""
 
-    pass
-
 
 _ParseAppCallable = Callable[[str], dict[str, Any]]
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,7 +48,7 @@ copyright_year_string = (
     if current_year == copyright_first_year
     else f"{copyright_first_year}-{current_year}"
 )
-copyright = f"{copyright_year_string}, {copyright_owners}. All rights reserved"  # noqa: A001
+copyright = f"{copyright_year_string}, {copyright_owners}. All rights reserved"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,7 @@ show-fixes = true
 
 [tool.ruff.lint]
 ignore = ["E501", "E402", "B904", "TRY003", "PLC0415"]
-select = [
+extend-select = [
   "A",    # flake8-builtins
   "ARG",  # flake8-unused-arguments
   "B",    # flake8-bugbear

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,28 +123,6 @@ push = true
 line-length = 88
 show-fixes = true
 
-[tool.ruff.lint]
-ignore = ["E501", "E402", "B904", "TRY003", "PLC0415"]
-extend-select = [
-  "A",    # flake8-builtins
-  "ARG",  # flake8-unused-arguments
-  "B",    # flake8-bugbear
-  "C4",   # flake8-comprehensions
-  "E",    # pycodestyle
-  "F",    # pyflakes
-  "I",    # isort
-  "N",    # pep8-naming
-  "PLE",  # pylint error rules
-  "PLW",  # pylint warning rules
-  "PLC",  # pylint convention rules
-  "RUF",  # ruff-specific rules
-  "TRY",  # Tryceratops
-  "UP"    # pyupgrade
-]
-
-[tool.ruff.lint.per-file-ignores]
-"tests/*" = ["ARG001"]
-
 [tool.pytest.ini_options]
 addopts = '--strict-config --strict-markers -ra --durations-min=1 --durations=10'
 markers = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,7 +82,7 @@ def forbid_external_commands(monkeypatch):
 
     monkeypatch.setattr(
         "aiidalab.utils.run_pip_install",
-        lambda python_bin: raise_exc("Running `pip install` not allowed in tests!"),  # noqa: ARG005
+        lambda python_bin: raise_exc("Running `pip install` not allowed in tests!"),
     )
 
     monkeypatch.setattr(


### PR DESCRIPTION
ruff 0.16.0 hugely expanded its default rule set from 59 to 413 rules. I propose to use this new default and simplify our current ruff configuration, since there is anyway a big overlap with what we had enabled, and I generally trust the astral team to do a good job of picking up important rules. 

See https://astral.sh/blog/ruff-v0.16.0#better-default-rule-set for more details. 

@yakutovicha @edan-bainglass if this sounds like a good plan, I'll do the same for the other repos. 