### PR TITLE
Discard str-casting of metadata values

### DIFF
--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from subprocess import CalledProcessError
 from threading import Thread
 from time import sleep
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import urldefrag, urlsplit, urlunsplit
 from uuid import uuid4
 
@@ -38,7 +38,7 @@ from watchdog.observers.polling import PollingObserver
 from .environment import Environment
 from .git_util import GitManagedAppRepo as Repo
 from .git_util import git_clone
-from .metadata import Metadata
+from .metadata import Metadata, MetadataType
 from .utils import (
     FIND_INSTALLED_PACKAGES_CACHE,
     Package,
@@ -776,7 +776,7 @@ class AiidaLabApp(traitlets.HasTraits):
     def __init__(
         self,
         name: str,
-        app_data: dict[str, Any] | None,
+        app_data: dict[str, MetadataType] | None,
         aiidalab_apps_path: str | None,
         watch: bool = True,
     ):
@@ -998,33 +998,33 @@ class AiidaLabApp(traitlets.HasTraits):
         """Return metadata dictionary. Give the priority to the local copy (better for the developers)."""
         return self._app.metadata
 
-    def _get_from_metadata(self, what: str) -> Any:
+    def _get_from_metadata(self, what: str) -> MetadataType:
         """Get information from metadata."""
         try:
-            return self._app.metadata[what]
+            return cast(MetadataType, self._app.metadata[what])
         except KeyError:
             return f'Field "{what}" is not present in app metadata.'
 
     @property
     def authors(self) -> str:
-        return self._get_from_metadata("authors")
+        return cast(str, self._get_from_metadata("authors"))
 
     @property
     def description(self) -> str:
-        return self._get_from_metadata("description")
+        return cast(str, self._get_from_metadata("description"))
 
     @property
     def title(self) -> str:
-        return self._get_from_metadata("title")
+        return cast(str, self._get_from_metadata("title"))
 
     @property
     def url(self) -> str:
         """Provide explicit link to Git repository."""
-        return self._get_from_metadata("external_url")
+        return cast(str, self._get_from_metadata("external_url"))
 
     @property
     def citations(self) -> list[dict[str, Any]]:
-        return self._get_from_metadata("citations")
+        return cast(list[dict[str, Any]], self._get_from_metadata("citations"))
 
     @property
     def more(self) -> str:

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -998,10 +998,10 @@ class AiidaLabApp(traitlets.HasTraits):
         """Return metadata dictionary. Give the priority to the local copy (better for the developers)."""
         return self._app.metadata
 
-    def _get_from_metadata(self, what: str) -> str:
+    def _get_from_metadata(self, what: str) -> Any:
         """Get information from metadata."""
         try:
-            return f"{self._app.metadata[what]}"
+            return self._app.metadata[what]
         except KeyError:
             return f'Field "{what}" is not present in app metadata.'
 
@@ -1023,7 +1023,7 @@ class AiidaLabApp(traitlets.HasTraits):
         return self._get_from_metadata("external_url")
 
     @property
-    def citations(self) -> str:
+    def citations(self) -> list[dict[str, Any]]:
         return self._get_from_metadata("citations")
 
     @property

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from subprocess import CalledProcessError
 from threading import Thread
 from time import sleep
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urldefrag, urlsplit, urlunsplit
 from uuid import uuid4
 
@@ -38,7 +38,7 @@ from watchdog.observers.polling import PollingObserver
 from .environment import Environment
 from .git_util import GitManagedAppRepo as Repo
 from .git_util import git_clone
-from .metadata import Metadata, MetadataType
+from .metadata import Metadata, MetadataDict
 from .utils import (
     FIND_INSTALLED_PACKAGES_CACHE,
     Package,
@@ -89,7 +89,7 @@ class AppRemoteUpdateStatus(Flag):
 
 @dataclass
 class _AiidaLabApp:
-    metadata: dict[str, Any]
+    metadata: MetadataDict
     name: str
     path: Path
     # TODO: It would be nicer to use parsed packaging.Version as a key instead of str
@@ -776,7 +776,7 @@ class AiidaLabApp(traitlets.HasTraits):
     def __init__(
         self,
         name: str,
-        app_data: dict[str, MetadataType] | None,
+        app_data: dict[str, Any] | None,
         aiidalab_apps_path: str | None,
         watch: bool = True,
     ):
@@ -994,37 +994,29 @@ class AiidaLabApp(traitlets.HasTraits):
         refresh_thread.start()
 
     @property
-    def metadata(self) -> dict[str, Any]:
+    def metadata(self) -> MetadataDict:
         """Return metadata dictionary. Give the priority to the local copy (better for the developers)."""
         return self._app.metadata
 
-    def _get_from_metadata(self, what: str) -> MetadataType:
-        """Get information from metadata."""
-        try:
-            return cast(MetadataType, self._app.metadata[what])
-        except KeyError:
-            return f'Field "{what}" is not present in app metadata.'
-
     @property
     def authors(self) -> str:
-        return cast(str, self._get_from_metadata("authors"))
+        return self._app.metadata.get("authors") or "No authors provided"
 
     @property
     def description(self) -> str:
-        return cast(str, self._get_from_metadata("description"))
+        return self._app.metadata.get("description") or "No description provided"
 
     @property
     def title(self) -> str:
-        return cast(str, self._get_from_metadata("title"))
+        return self._app.metadata.get("title") or "No title provided"
 
     @property
-    def url(self) -> str:
-        """Provide explicit link to Git repository."""
-        return cast(str, self._get_from_metadata("external_url"))
+    def url(self) -> str | None:
+        return self._app.metadata.get("external_url")
 
     @property
     def citations(self) -> list[dict[str, Any]]:
-        return cast(list[dict[str, Any]], self._get_from_metadata("citations"))
+        return self._app.metadata.get("citations") or []
 
     @property
     def more(self) -> str:

--- a/aiidalab/metadata.py
+++ b/aiidalab/metadata.py
@@ -6,9 +6,7 @@ from collections.abc import Generator
 from configparser import ConfigParser
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Union
-
-from typing_extensions import TypeAlias
+from typing import TYPE_CHECKING, Any, TypedDict
 
 if TYPE_CHECKING:
     from configparser import SectionProxy
@@ -172,4 +170,16 @@ class Metadata:
         raise ValueError(f"Directory '{root}' does not exist.")
 
 
-MetadataType: TypeAlias = Union[str, list[str], list[dict[str, Any]]]
+class MetadataDict(TypedDict):
+    """TypedDict for app metadata."""
+
+    title: str
+    description: str
+    authors: str | None
+    state: str | None
+    documentation_url: str | None
+    external_url: str | None
+    logo: str | None
+    categories: list[str]
+    version: str | None
+    citations: list[dict[str, Any]] | None

--- a/aiidalab/metadata.py
+++ b/aiidalab/metadata.py
@@ -6,7 +6,9 @@ from collections.abc import Generator
 from configparser import ConfigParser
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Union
+
+from typing_extensions import TypeAlias
 
 if TYPE_CHECKING:
     from configparser import SectionProxy
@@ -168,3 +170,6 @@ class Metadata:
                 return cls(**dict(cls._parse(path)))
 
         raise ValueError(f"Directory '{root}' does not exist.")
+
+
+MetadataType: TypeAlias = Union[str, list[str], list[dict[str, Any]]]

--- a/tests/test_appclass.py
+++ b/tests/test_appclass.py
@@ -61,6 +61,11 @@ def test_app_is_not_registered(generate_app, monkeypatch, tmp_path):
     assert len(app.available_versions) == 0
 
 
+def test_empty_app_citations(generate_app):
+    app = generate_app()
+    assert app.citations == []
+
+
 def test_app_watch(tmp_path):
     """Test the aiidalab app watch responsive to the app path changes."""
 


### PR DESCRIPTION
Some metadata values are lists and are expected as such in the template. See #524 for details on the bug.

Closes #524