### PR TITLE
Use `packaging.version.Version` when comparing versions

### DIFF
--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -27,7 +27,7 @@ from uuid import uuid4
 import requests
 import traitlets
 from dulwich.errors import NotGitRepository
-from packaging.version import Version
+from packaging.version import InvalidVersion, Version
 from watchdog.events import (
     EVENT_TYPE_CLOSED_NO_WRITE,
     EVENT_TYPE_OPENED,
@@ -287,7 +287,7 @@ class _AiidaLabApp:
             if (
                 available_versions
                 and isinstance(installed_version, str)
-                and Version(installed_version) != Version(available_versions[0])
+                and not self._version_equal(installed_version, available_versions[0])
             ):
                 return AppRemoteUpdateStatus.UPDATE_AVAILABLE
 
@@ -423,12 +423,17 @@ class _AiidaLabApp:
             for name, requirement in unmatched_dependencies.items()
         ]
 
+    def _version_equal(self, v1: str, v2: str) -> bool:
+        """Check if two versions are equal, considering PEP 440."""
+        try:
+            return Version(v1) == Version(v2)
+        except InvalidVersion:
+            return v1 == v2
+
     def _get_release(self, version: str) -> dict[str, Any]:
         """Return the registry release matching the given PEP 440 version."""
-        parsed_version = Version(version)
-
         for release_version, release in self.releases.items():
-            if Version(release_version) == parsed_version:
+            if self._version_equal(release_version, version):
                 return release  # type: ignore[no-any-return]
 
         raise KeyError(version)

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -287,7 +287,7 @@ class _AiidaLabApp:
             if (
                 available_versions
                 and isinstance(installed_version, str)
-                and not self._version_equal(installed_version, available_versions[0])
+                and not self._versions_equal(installed_version, available_versions[0])
             ):
                 return AppRemoteUpdateStatus.UPDATE_AVAILABLE
 
@@ -423,7 +423,7 @@ class _AiidaLabApp:
             for name, requirement in unmatched_dependencies.items()
         ]
 
-    def _version_equal(self, v1: str, v2: str) -> bool:
+    def _versions_equal(self, v1: str, v2: str) -> bool:
         """Check if two versions are equal, considering PEP 440."""
         try:
             return Version(v1) == Version(v2)
@@ -433,7 +433,7 @@ class _AiidaLabApp:
     def _get_release(self, version: str) -> dict[str, Any]:
         """Return the registry release matching the given PEP 440 version."""
         for release_version, release in self.releases.items():
-            if self._version_equal(release_version, version):
+            if self._versions_equal(release_version, version):
                 return release  # type: ignore[no-any-return]
 
         raise KeyError(version)

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -27,6 +27,7 @@ from uuid import uuid4
 import requests
 import traitlets
 from dulwich.errors import NotGitRepository
+from packaging.version import Version
 from watchdog.events import (
     EVENT_TYPE_CLOSED_NO_WRITE,
     EVENT_TYPE_OPENED,
@@ -283,7 +284,11 @@ class _AiidaLabApp:
 
             # Check whether the locally installed version is the latest release.
             available_versions = list(self.available_versions(prereleases=prereleases))
-            if available_versions and installed_version != available_versions[0]:
+            if (
+                available_versions
+                and isinstance(installed_version, str)
+                and Version(installed_version) != Version(available_versions[0])
+            ):
                 return AppRemoteUpdateStatus.UPDATE_AVAILABLE
 
             # App must be up-to-date.
@@ -373,7 +378,7 @@ class _AiidaLabApp:
         if not self.is_registered() or self.is_detached():
             environment = asdict(Environment.scan(self.path))
         else:
-            environment = self.releases[version].get("environment", {})
+            environment = self._get_release(version).get("environment", {})
 
         for key, spec in environment.items():
             if key == "python_requirements":
@@ -417,6 +422,16 @@ class _AiidaLabApp:
             }
             for name, requirement in unmatched_dependencies.items()
         ]
+
+    def _get_release(self, version: str) -> dict[str, Any]:
+        """Return the registry release matching the given PEP 440 version."""
+        parsed_version = Version(version)
+
+        for release_version, release in self.releases.items():
+            if Version(release_version) == parsed_version:
+                return release  # type: ignore[no-any-return]
+
+        raise KeyError(version)
 
     def _install_dependencies(self, python_bin: str, stdout: Any) -> None:
         """Try to install the app dependencies with pip (if specified)."""

--- a/aiidalab/app.py
+++ b/aiidalab/app.py
@@ -423,12 +423,15 @@ class _AiidaLabApp:
             for name, requirement in unmatched_dependencies.items()
         ]
 
-    def _versions_equal(self, v1: str, v2: str) -> bool:
+    def _versions_equal(self, left: str | AppVersion, right: str | AppVersion) -> bool:
         """Check if two versions are equal, considering PEP 440."""
+        if not isinstance(left, str) or not isinstance(right, str):
+            return left is right
+
         try:
-            return Version(v1) == Version(v2)
+            return Version(left) == Version(right)
         except InvalidVersion:
-            return v1 == v2
+            return left == right
 
     def _get_release(self, version: str) -> dict[str, Any]:
         """Return the registry release matching the given PEP 440 version."""

--- a/tests/test_appclass.py
+++ b/tests/test_appclass.py
@@ -6,7 +6,7 @@ from time import sleep
 import pytest
 import traitlets
 
-from aiidalab.app import AiidaLabApp, AiidaLabAppWatch
+from aiidalab.app import AiidaLabApp, AiidaLabAppWatch, AppVersion
 
 
 def test_init_refresh(generate_app):
@@ -131,3 +131,10 @@ def test_app_version_compatibility(generate_app):
     assert app._app._versions_equal("my-release-1", "my-release-1")
     assert not app._app._versions_equal("my-release-1", "my-release-2")
     assert not app._app._versions_equal("my-release-1", "26.6.11")
+
+    assert app._app._versions_equal(AppVersion.UNKNOWN, AppVersion.UNKNOWN)
+    assert app._app._versions_equal(AppVersion.NOT_INSTALLED, AppVersion.NOT_INSTALLED)
+
+    assert not app._app._versions_equal(AppVersion.UNKNOWN, AppVersion.NOT_INSTALLED)
+    assert not app._app._versions_equal(AppVersion.UNKNOWN, "26.6.11")
+    assert not app._app._versions_equal("26.6.11", AppVersion.UNKNOWN)

--- a/tests/test_appclass.py
+++ b/tests/test_appclass.py
@@ -109,3 +109,25 @@ def test_app_watch(tmp_path):
     testfile.touch()
 
     assert app.x == 4
+
+
+def test_app_version_compatibility(generate_app):
+    """Test the version compatibility check.
+
+    The registered versions are tag format (e.g., "v26.06.11"), whereas the app metadata version
+    is of format 26.6.11. This leads to failed version comparisons. This is resolved by using the
+    `packaging.version.Version` class to parse and compare versions correctly. However, since Git
+    tags can be anything (e.g., "my-release-1"), we try/except the use of `Version`, defaulting to
+    the raw string comparison if parsing fails.
+
+    This test checks the various scenarios.
+    """
+    app = generate_app()
+
+    assert app._app._versions_equal("v26.06.11", "26.6.11")
+    assert app._app._versions_equal("26.06.11", "26.6.11")
+    assert not app._app._versions_equal("v26.06.11", "26.6.12")
+
+    assert app._app._versions_equal("my-release-1", "my-release-1")
+    assert not app._app._versions_equal("my-release-1", "my-release-2")
+    assert not app._app._versions_equal("my-release-1", "26.6.11")


### PR DESCRIPTION
This PR resolves a mismatch between registered release format 
(tag format, e.g., v26.06.11) and app metadata format (e.g., 26.6.11)
by leveraging `packaging.version.Version`, which sees the two as
equivalent. This solves the false negatives reported for AiiDAlab apps
leading to wrong "App incompatible" messaging.